### PR TITLE
feat: add user notifications endpoint and mention search functionality

### DIFF
--- a/crates/core/database/src/models/admin_migrations/ops/mongodb/init.rs
+++ b/crates/core/database/src/models/admin_migrations/ops/mongodb/init.rs
@@ -140,6 +140,12 @@ pub async fn create_database(db: &MongoDb) {
             },
             {
                 "key": {
+                    "mentions": 1_i32
+                },
+                "name": "mentions"
+            },
+            {
+                "key": {
                     "channel": 1_i32,
                     "_id": 1_i32
                 },

--- a/crates/core/database/src/models/admin_migrations/ops/mongodb/scripts.rs
+++ b/crates/core/database/src/models/admin_migrations/ops/mongodb/scripts.rs
@@ -25,7 +25,7 @@ struct MigrationInfo {
     revision: i32,
 }
 
-pub const LATEST_REVISION: i32 = 50; // MUST BE +1 to last migration
+pub const LATEST_REVISION: i32 = 51; // MUST BE +1 to last migration
 
 pub async fn migrate_database(db: &MongoDb) {
     let migrations = db.col::<Document>("migrations");
@@ -1305,6 +1305,26 @@ pub async fn run_migrations(db: &MongoDb, revision: i32) -> i32 {
                 .unwrap();
         }
     };
+
+    if revision <= 50 {
+        info!("Running migration [revision 50 / 06-04-2026]: Create index on mentions array.");
+
+        db.db()
+            .run_command(doc! {
+                "createIndexes": "messages",
+                "indexes": [
+                    {
+                        "key": {
+                            "mentions": 1_i32
+                        },
+                        "name": "mentions"
+                    }
+                ]
+            })
+            .await
+            .expect("Failed to create message mentions index.");
+    };
+
 
     // Reminder to update LATEST_REVISION when adding new migrations.
     LATEST_REVISION.max(revision)

--- a/crates/core/database/src/models/messages/model.rs
+++ b/crates/core/database/src/models/messages/model.rs
@@ -190,6 +190,8 @@ auto_derived!(
         pub query: Option<String>,
         /// Search for pinned
         pub pinned: Option<bool>,
+        /// Search for mentions
+        pub mentioned: Option<String>,
     }
 
     /// Message Query

--- a/crates/core/database/src/models/messages/ops/mongodb.rs
+++ b/crates/core/database/src/models/messages/ops/mongodb.rs
@@ -59,6 +59,10 @@ impl AbstractMessages for MongoDb {
             filter.insert("pinned", pinned);
         };
 
+        if let Some(mentioned) = query.filter.mentioned {
+            filter.insert("mentions", mentioned);
+        }
+
         // 2. Find query limit
         let limit = query.limit.unwrap_or(50);
 

--- a/crates/delta/src/routes/users/mod.rs
+++ b/crates/delta/src/routes/users/mod.rs
@@ -16,12 +16,14 @@ mod open_dm;
 mod remove_friend;
 mod send_friend_request;
 mod unblock_user;
+mod notifications;
 
 pub fn routes() -> (Vec<Route>, OpenApi) {
     openapi_get_routes_spec![
         // User Information
         fetch_self::fetch,
         fetch_user::fetch,
+        notifications::notifications,
         fetch_user_flags::fetch_user_flags,
         edit_user::edit,
         change_username::change_username,

--- a/crates/delta/src/routes/users/notifications.rs
+++ b/crates/delta/src/routes/users/notifications.rs
@@ -1,0 +1,34 @@
+use revolt_database::{Database, Message, MessageFilter, MessageQuery, MessageTimePeriod, User};
+use revolt_models::v0::{self, MessageSort};
+use revolt_result::Result;
+use rocket::{serde::json::Json, State};
+
+#[openapi(tag = "User")]
+#[get("/@me/notifications")]
+pub async fn notifications(
+    db: &State<Database>,
+    user: User,
+) -> Result<Json<v0::BulkMessageResponse>> {
+    let query = MessageQuery {
+        filter: MessageFilter {
+            mentioned: Some(user.id.to_string()), // Search for the user's ID in mentions
+            ..Default::default()
+        },
+        time_period: MessageTimePeriod::Absolute {
+            before: None,
+            after: None,
+            sort: Some(MessageSort::Latest),
+        },
+        limit: Some(50),
+    };
+
+    Message::fetch_with_users(
+        db,
+        query,
+        &user,
+        Some(true),
+        None,
+    )
+        .await
+        .map(Json)
+}


### PR DESCRIPTION
### Changes
* **New Route**: Added `GET /users/@me/notifications` in `delta` to fetch the 50 most recent messages mentioning the current user.
* **Database Updates**: 
  * Added `mentioned` field to `MessageFilter`.
  * Updated MongoDB querying logic to filter messages by the `mentions` array.
  * Added a new database migration (`revision 51`) and initialization scripts to create an index on the `mentions` array in the `messages` collection, optimizing query performance. Unsure how would Stoat handle this with millions of messages

## Current Issues
* **Role & Everyone Pings**: Currently, this prototype only searches for direct user mentions. Support for role mentions and `@everyone` tags will be addressed in future progress.
* **Server Scoping & Missing Context**: If an user loses access to a channel, they shouldn't see mentions from those channels (or they might appear without context) and vice versa. Currently it uses `mentions` field in `Message` struct and they don't get updated if an user gets access to a channel or loses it
* And possibly a few more I didn't think about

This PR is opened as draft so I know how to progress on this while keeping a clear history.