### PR TITLE
fix: use correct response for NoEffect errors

### DIFF
--- a/crates/core/result/src/axum.rs
+++ b/crates/core/result/src/axum.rs
@@ -36,9 +36,7 @@ impl IntoResponse for Error {
             ErrorType::NotInGroup => StatusCode::NOT_FOUND,
             ErrorType::AlreadyPinned => StatusCode::BAD_REQUEST,
             ErrorType::NotPinned => StatusCode::BAD_REQUEST,
-            ErrorType::InSlowmode {
-                retry_after: _,
-            } => StatusCode::TOO_MANY_REQUESTS,
+            ErrorType::InSlowmode { retry_after: _ } => StatusCode::TOO_MANY_REQUESTS,
 
             ErrorType::CantCreateServers => StatusCode::FORBIDDEN,
             ErrorType::UnknownServer => StatusCode::NOT_FOUND,
@@ -78,7 +76,7 @@ impl IntoResponse for Error {
             ErrorType::DuplicateNonce => StatusCode::CONFLICT,
             ErrorType::VosoUnavailable => StatusCode::BAD_REQUEST,
             ErrorType::NotFound => StatusCode::NOT_FOUND,
-            ErrorType::NoEffect => StatusCode::OK,
+            ErrorType::NoEffect => StatusCode::BAD_REQUEST,
             ErrorType::FailedValidation { .. } => StatusCode::BAD_REQUEST,
             ErrorType::LiveKitUnavailable => StatusCode::BAD_REQUEST,
             ErrorType::NotConnected => StatusCode::BAD_REQUEST,

--- a/crates/core/result/src/rocket.rs
+++ b/crates/core/result/src/rocket.rs
@@ -42,9 +42,7 @@ impl<'r> Responder<'r, 'static> for Error {
             ErrorType::NotInGroup => Status::NotFound,
             ErrorType::AlreadyPinned => Status::BadRequest,
             ErrorType::NotPinned => Status::BadRequest,
-            ErrorType::InSlowmode {
-                retry_after: _,
-            } => Status::TooManyRequests,
+            ErrorType::InSlowmode { retry_after: _ } => Status::TooManyRequests,
             ErrorType::InvalidFlagValue => Status::BadRequest,
 
             ErrorType::CantCreateServers => Status::Forbidden,
@@ -84,7 +82,7 @@ impl<'r> Responder<'r, 'static> for Error {
             ErrorType::NotAuthenticated => Status::Unauthorized,
             ErrorType::DuplicateNonce => Status::Conflict,
             ErrorType::NotFound => Status::NotFound,
-            ErrorType::NoEffect => Status::Ok,
+            ErrorType::NoEffect => Status::BadRequest,
             ErrorType::FailedValidation { .. } => Status::BadRequest,
             ErrorType::LiveKitUnavailable => Status::BadRequest,
             ErrorType::NotAVoiceChannel => Status::BadRequest,


### PR DESCRIPTION
<!-- Describe your changes -->

NoEffect errors were wrapping Response::Ok which is not fine, so it has been changed to Response::BadRequest. This might wrap other places where NoEffect is used, but I think BadRequest fits all of them.

Fixes #400

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Sent a friend request to myself and looked at the response (the for-web client showed up an expected error message)

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No LLMs allowed in mah Rust code

- `main` <!-- branch-stack -->
  - \#732 :point\_left:
