### PR TITLE
fix: encode filenames in redirects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6820,7 +6820,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid 1.2.1",
- "urlencoding",
+ "url-escape",
  "utoipa",
  "utoipa-scalar",
  "webp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6820,6 +6820,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid 1.2.1",
+ "urlencoding",
  "utoipa",
  "utoipa-scalar",
  "webp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ url = "2.2.2"
 impl_ops = "0.1.1"
 lazy_static = "1.5.0"
 mime = "0.3.17"
+urlencoding = "2.1.3"
 
 # Build Dependencies
 vergen = "7.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,6 @@ url = "2.2.2"
 impl_ops = "0.1.1"
 lazy_static = "1.5.0"
 mime = "0.3.17"
-urlencoding = "2.1.3"
 
 # Build Dependencies
 vergen = "7.5.0"

--- a/crates/services/autumn/Cargo.toml
+++ b/crates/services/autumn/Cargo.toml
@@ -31,6 +31,7 @@ imagesize = { workspace = true }
 # Utility
 lazy_static = { workspace = true }
 moka = { workspace = true, features = ["future"] }
+urlencoding = { workspace = true }
 
 # Serialisation
 strum_macros = { workspace = true }

--- a/crates/services/autumn/Cargo.toml
+++ b/crates/services/autumn/Cargo.toml
@@ -31,8 +31,7 @@ imagesize = { workspace = true }
 # Utility
 lazy_static = { workspace = true }
 moka = { workspace = true, features = ["future"] }
-urlencoding = { workspace = true }
-
+url-escape = { workspace = true }
 # Serialisation
 strum_macros = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/services/autumn/src/api.rs
+++ b/crates/services/autumn/src/api.rs
@@ -24,6 +24,7 @@ use sha2::Digest;
 use tempfile::NamedTempFile;
 use tokio::time::Instant;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
+use urlencoding::encode;
 use utoipa::ToSchema;
 
 use crate::{
@@ -479,8 +480,10 @@ async fn fetch_file(
     // Ensure filename is correct
     if file_name != file.filename {
         if file_name == "original" {
+            let safe_filename = encode(&file.filename);
+
             return Ok(
-                Redirect::permanent(&format!("/{tag}/{file_id}/{}", file.filename)).into_response(),
+                Redirect::permanent(&format!("/{tag}/{file_id}/{}", safe_filename)).into_response(),
             );
         }
 

--- a/crates/services/autumn/src/api.rs
+++ b/crates/services/autumn/src/api.rs
@@ -24,7 +24,7 @@ use sha2::Digest;
 use tempfile::NamedTempFile;
 use tokio::time::Instant;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
-use urlencoding::encode;
+use url_escape::encode_component;
 use utoipa::ToSchema;
 
 use crate::{
@@ -480,7 +480,7 @@ async fn fetch_file(
     // Ensure filename is correct
     if file_name != file.filename {
         if file_name == "original" {
-            let safe_filename = encode(&file.filename);
+            let safe_filename = encode_component(&file.filename);
 
             return Ok(
                 Redirect::permanent(&format!("/{tag}/{file_id}/{}", safe_filename)).into_response(),


### PR DESCRIPTION
<!-- Describe your changes -->

Encodes file name to ensure clients can do a proper fetch

Fixes #736

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Observed broken files due to redirect, they worked after this change

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None

- `main` <!-- branch-stack -->
  - \#737 :point\_left:
