### PR TITLE
fix: amqprs startup bug

### DIFF
--- a/crates/core/database/src/amqp/amqp.rs
+++ b/crates/core/database/src/amqp/amqp.rs
@@ -29,7 +29,7 @@ impl AMQP {
         }
     }
 
-    pub async fn new_auto() -> AMQP {
+    pub async fn new_auto() -> revolt_result::Result<AMQP> {
         let config = revolt_config::config().await;
 
         let connection = Connection::open(&OpenConnectionArguments::new(
@@ -46,20 +46,25 @@ impl AMQP {
             .await
             .expect("Failed to open RabbitMQ channel");
 
-        channel
-            .exchange_declare(
-                ExchangeDeclareArguments::new(&config.pushd.exchange, "direct")
-                    .durable(true)
-                    .finish(),
-            )
-            .await
-            .expect("Failed to declare exchange");
-
-        AMQP::new(connection, channel)
+        let mut resp = AMQP::new(connection, channel);
+        resp.configure_channels().await?;
+        Ok(resp)
     }
 
-    pub async fn configure_channels(&self) -> revolt_result::Result<()> {
+    pub async fn repoen_channel(&mut self) {
+        self.channel = self
+            .connection
+            .open_channel(None)
+            .await
+            .expect("Failed to open RabbitMQ channel");
+    }
+
+    pub async fn configure_channels(&mut self) -> revolt_result::Result<()> {
         let config = revolt_config::config().await;
+
+        if !self.channel.is_open() {
+            self.repoen_channel().await;
+        }
 
         self.channel
             .exchange_declare(

--- a/crates/delta/src/main.rs
+++ b/crates/delta/src/main.rs
@@ -119,7 +119,7 @@ pub async fn web() -> Rocket<Build> {
         .await
         .expect("Failed to declare exchange");
 
-    let amqp = AMQP::new(connection, channel);
+    let mut amqp = AMQP::new(connection, channel);
     amqp.configure_channels()
         .await
         .expect("Failed to configure channels");


### PR DESCRIPTION
<!-- Describe your changes -->

A quick patch over the amqprs startup issue, where the channel closes itself. Hard to diagnose, but this may bandaid over it for now.

## How was this PR tested?

ran locally and observed a successful creation of the exchange.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

N/A

- `main` <!-- branch-stack -->
  - \#744 :point\_left:
