### PR TITLE
fix: update default exchange to `revolt.default`

### DIFF
--- a/crates/core/config/Revolt.toml
+++ b/crates/core/config/Revolt.toml
@@ -30,7 +30,7 @@ host = "rabbit"
 port = 5672
 username = "rabbituser"
 password = "rabbitpass"
-default_exchange = "revolt"
+default_exchange = "revolt.default"
 
 [rabbit.queues]
 acks = "internal.ack"


### PR DESCRIPTION
Pretty sure our current production rabbit does not let you bind `revolt` with the permissions as-is, and on top of that there is an existing `revolt` direct exchange which may or may not be replaced (I don't know) by the topic exchange.

Being unfamiliar with Rabbit, this is just my proposed quick patch to get the update rolling and then we can patch up the permissions/state on Rabbit after. (assuming this is the issue)

- `main` <!-- branch-stack -->
  - \#746 :point\_left:
