### PR TITLE
fix: point docs favicon to correct location

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -6,7 +6,7 @@ import type { ScalarOptions } from '@scalar/docusaurus';
 const config: Config = {
   title: 'Stoat Developers',
   tagline: 'Developer documentation for Stoat',
-  favicon: 'https://stoat.chat/favicon.svg',
+  favicon: 'https://stoat.chat/favicon-stoat.svg',
 
   future: {
     v4: true,


### PR DESCRIPTION
Just a simple change of `https://stoat.chat/favicon.svg` to `https://stoat.chat/favicon-stoat.svg` as it was majorly bugging me to see no icon in the top left nor the tab.


Before:
<img width="205" height="55" alt="image" src="https://github.com/user-attachments/assets/3e4d78c1-740c-49b6-a9a7-ca32884cc2a6" />
<img width="142" height="41" alt="image" src="https://github.com/user-attachments/assets/71b4972e-291f-4c06-b4ba-af46956293d9" />
After:
<img width="163" height="48" alt="image" src="https://github.com/user-attachments/assets/18c1f3e9-f0dd-417a-a8c1-04a31b0ea508" />
<img width="160" height="42" alt="image" src="https://github.com/user-attachments/assets/7d251a50-0a75-4b11-804c-3684581100d1" />


- [X] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation if applicable
- [X] I have no unrelated changes in the PR
- [X] I have confirmed that any new dependencies are strictly necessary
- [X] I have written tests for new code (if applicable)
- [X] I have followed naming conventions/patterns in the surrounding code