### PR TITLE
fix: channel role permissions fail with 400 InvalidOperation for server owners/admins

### DIFF
--- a/crates/delta/src/routes/channels/permissions_set.rs
+++ b/crates/delta/src/routes/channels/permissions_set.rs
@@ -2,7 +2,7 @@ use revolt_database::{
     util::{permissions::DatabasePermissionQuery, reference::Reference}, voice::{sync_voice_permissions, VoiceClient}, Database, User
 };
 use revolt_models::v0;
-use revolt_permissions::{calculate_channel_permissions, ChannelPermission, Override};
+use revolt_permissions::{calculate_channel_permissions, ChannelPermission, Override, PermissionQuery};
 use revolt_result::{create_error, Result};
 use rocket::{serde::json::Json, State};
 
@@ -24,6 +24,8 @@ pub async fn set_role_permissions(
     let channel = target.as_channel(db).await?;
     let mut query = DatabasePermissionQuery::new(db, &user).channel(&channel);
     let permissions: revolt_permissions::PermissionValue = calculate_channel_permissions(&mut query).await;
+
+    query.set_server_from_channel().await;
 
     permissions.throw_if_lacking_channel_permission(ChannelPermission::ManagePermissions)?;
 


### PR DESCRIPTION
<!-- Describe your changes -->

`calculate_channel_permissions()` returns early for privileged users (server owners, platform-privileged accounts, GrantAllSafe) without ever calling `set_server_from_channel`, so `query.server_ref()` stays `None` even though the channel unambiguously belongs to a server. The route then throws a bogus `400 InvalidOperation`, meaning server owners/admins can never set channel-level role permissions via the API or web UI.

Fix: explicitly populate the server reference via `set_server_from_channel()` before relying on `server_ref()`.

Fixes # (no tracked issue — found via manual testing on a self-hosted instance)

## How was this PR tested?

- [x] Reproduced the bug: owner/admin attempts to PUT `/channels/{id}/permissions/{role_id}` returned `400 InvalidOperation` even though `ManagePermissions` was held
- [x] Applied the fix locally and confirmed the same request now correctly proceeds to the role lookup / permission-override logic instead of failing early
- [x] Confirmed non-owners without `ManagePermissions` are still correctly rejected (no regression)

## Checklist:

- [x] I have carefully read the contributing guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable (n/a — internal logic fix, no public-facing docs affected)
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary (none added)
- [ ] I have written tests for new code (happy to add a regression test if there's a preferred pattern/location for permission-route tests — pointers welcome)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Used an LLM-based coding assistant to help trace the call path through `calculate_channel_permissions` / `DatabasePermissionQuery` and draft the fix and this description. The root-cause diagnosis and fix were verified by hand against the actual source and tested against a running instance.