### PR TITLE
fix: server owner should bypass rank check on channel role-permission overrides

### DIFF
--- a/crates/delta/src/routes/channels/permissions_set.rs
+++ b/crates/delta/src/routes/channels/permissions_set.rs
@@ -29,7 +29,9 @@ pub async fn set_role_permissions(
 
     if let Some(server) = query.server_ref() {
         if let Some(role) = server.roles.get(&role_id) {
-            if role.rank <= query.get_member_rank().unwrap_or(i64::MIN) {
+            if server.owner != user.id
+                && role.rank <= query.get_member_rank().unwrap_or(i64::MIN)
+            {
                 return Err(create_error!(NotElevated));
             }
 


### PR DESCRIPTION
<!-- Describe your changes -->

`set_role_permissions` blocks editing a role's channel permission overrides whenever `role.rank <= acting_member_rank` (`NotElevated`), to prevent privilege-escalation loops. This check has no exemption for the server's true owner (`server.owner == user.id`).

Most servers have the owner also hold their own top-level role (e.g. "Admin"/"Server Admin") for visible status — meaning that role's rank is, by definition, equal to the owner's own computed member rank. The check then incorrectly throws `NotElevated` for the owner themselves, who unambiguously outranks everyone including their own role's other members.

Fix: short-circuit the rank check when the acting user is the server's owner — consistent with how true ownership is already treated as an absolute bypass elsewhere in the permission system (e.g. the channel-visibility lockout cascade).

Fixes # (no tracked issue — found via manual testing on a self-hosted instance, related to #802)

## How was this PR tested?

- [x] Reproduced: an owner account holding only `Server Admin` (their highest/only role) gets `NotElevated` when editing that role's channel overrides via the API and UI
- [x] With the patch, the same owner account can successfully grant/modify channel permission overrides for their own role (verified end-to-end against a running instance — change persisted and was confirmed via the API)
- [x] Confirmed non-owner members holding the same role are still correctly blocked by the existing rank check (no regression to the privilege-escalation protection)

## Checklist:

- [x] I have carefully read the contributing guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable (n/a — internal logic fix)
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary (none added)
- [ ] I have written tests for new code (happy to add a regression test if there's a preferred pattern/location)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Used an LLM-based coding assistant to help trace the permission-check call path and draft the fix and this description. Root-cause diagnosis and the fix itself were verified by hand and tested live against a running instance (including confirming the change persists via direct API inspection).