### PR TITLE
fix: store rejoined member timestamp in milliseconds

### DIFF
--- a/crates/core/database/src/models/server_members/model.rs
+++ b/crates/core/database/src/models/server_members/model.rs
@@ -368,12 +368,22 @@ mod tests {
                 .await
                 .unwrap();
 
+            let before_rejoin = Timestamp::now_utc() - Duration::seconds(1);
             let kickable_member = Member::create(&db, &server, &kickable_user, None)
                 .await
                 .unwrap()
                 .0;
 
-            assert!(kickable_member.in_timeout())
+            assert!(kickable_member.in_timeout());
+            assert!(
+                kickable_member
+                    .joined_at
+                    .duration_since(Timestamp::UNIX_EPOCH)
+                    .whole_milliseconds()
+                    >= before_rejoin
+                        .duration_since(Timestamp::UNIX_EPOCH)
+                        .whole_milliseconds()
+            );
         });
     }
 }

--- a/crates/core/database/src/models/server_members/ops/mongodb.rs
+++ b/crates/core/database/src/models/server_members/ops/mongodb.rs
@@ -35,7 +35,10 @@ impl AbstractServerMembers for MongoDb {
                     },
                     doc! {
                         "$set": {
-                            "joined_at": member.joined_at.duration_since(Timestamp::UNIX_EPOCH).whole_seconds(),
+                            "joined_at": member
+                                .joined_at
+                                .duration_since(Timestamp::UNIX_EPOCH)
+                                .whole_milliseconds() as i64,
                         },
                         "$unset": {
                             "pending_deletion_at": ""


### PR DESCRIPTION
Fixes #776

## What changed
- Store `server_members.joined_at` as epoch milliseconds when restoring a soft-deleted MongoDB member record during rejoin.
- Extend the existing Mongo-only `muted_member_rejoin` regression test to assert the restored member has a current-era `joined_at` timestamp, while preserving the timeout behavior the test already covered.

## Why
`Member.joined_at` is serialized as a millisecond timestamp elsewhere, but the MongoDB rejoin path was writing `whole_seconds()`. When that value was later read as milliseconds, rejoined members appeared to have joined in January 1970.

## Testing
- `git diff --check`

Not run locally:
- `cargo fmt`
- `mise test` / `cargo nextest run`

The local Codex environment used for this change does not have `cargo`, `rustup`, or `mise` installed on PATH.

## LLM usage
Codex was used to inspect the issue, make the focused code change, and prepare this PR description.