### PR TITLE
fix: migration script would panic on fresh installations since it couldn't find invites collection

### DIFF
--- a/crates/core/database/src/models/admin_migrations/ops/mongodb/scripts.rs
+++ b/crates/core/database/src/models/admin_migrations/ops/mongodb/scripts.rs
@@ -1478,16 +1478,22 @@ pub async fn run_migrations(db: &MongoDb, revision: i32) -> i32 {
     if revision <= 50 {
         info!("Running migration [revision 50 / 13-04-2026]: Rename invites collection to account_invites");
 
-        db.db()
+        let result = db.db()
             .client()
             .database("admin")
             .run_command(doc! {
-                "renameCollection": "revolt.invites",
-                "to": "revolt.account_invites",
-                "dropTarget": true
-            })
-            .await
-            .unwrap();
+            "renameCollection": "revolt.invites",
+            "to": "revolt.account_invites",
+            "dropTarget": true
+        })
+            .await;
+
+        if let Err(e) = result {
+            // NamespaceNotFound (26) = source collection doesn't exist, safe to ignore
+            if !matches!(e.kind.as_ref(), mongodb::error::ErrorKind::Command(ce) if ce.code == 26) {
+                panic!("Failed to rename invites collection: {e}");
+            }
+        }
     }
 
     // Reminder to update LATEST_REVISION when adding new migrations.


### PR DESCRIPTION
<!-- Describe your changes -->

Fresh installations would get the error

```
[service:api] thread 'main' (69485) panicked at crates/core/database/src/models/admin_migrations/ops/mongodb/scripts.rs:1490:14:
[service:api] called `Result::unwrap()` on an `Err` value: Error { kind: Command(CommandError { code: 26, code_name: "NamespaceNotFound", message: "Source collection revolt.invites does not exist", topology_version: None }), labels: {}, wire_version: Some(27), source: None, server_response: Some(RawDocumentBuf { data: "f4000000016f6b000000000000000000026572726d73670030000000536f7572636520636f6c6c656374696f6e207265766f6c742e696e766974657320646f6573206e6f742065786973740010636f6465001a00000002636f64654e616d6500120000004e616d6573706163654e6f74466f756e64000324636c757374657254696d65005800000011636c757374657254696d650002000000547b396a037369676e6174757265003300000005686173680014000000000000000000000000000000000000000000000000126b657949640000000000000000000000116f7065726174696f6e54696d650002000000547b396a00" }) }
[service:api] note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Finished in 7.18s
[service:api] ERROR task failed
```

error if they did a fresh installation
Fixes # (issue)

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Migration was successful with this

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI used

- `main` <!-- branch-stack -->
  - \#820 :point\_left:
