### PR TITLE
fix: Option::Error caused endpoints that used ValidatedTicket become inaccessible to bots

### DIFF
--- a/crates/core/database/src/models/mfa_tickets/rocket.rs
+++ b/crates/core/database/src/models/mfa_tickets/rocket.rs
@@ -51,7 +51,7 @@ impl<'r> FromRequest<'r> for ValidatedTicket {
                         Outcome::Error((Status::Forbidden, create_error!(InvalidToken)))
                     }
                 } else {
-                    Outcome::Error((Status::Forbidden, create_error!(InvalidToken)))
+                    Outcome::Forward(Status::Unauthorized)
                 }
             }
             Outcome::Forward(f) => Outcome::Forward(f),


### PR DESCRIPTION
<!-- Describe your changes -->

Instead of Error'ing forwarding with Unauthorized should cause Option to be None instead of 401'ing
Fixes #819

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] PATCH /servers/ worked with these changes
- [x] Logged ValidatedTicket and it returns None

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

No AI was used

- `main` <!-- branch-stack -->
  - \#821 :point\_left:
