### PR TITLE
fix: allow removing channel slowmode

### DIFF
--- a/crates/core/database/src/models/channels/model.rs
+++ b/crates/core/database/src/models/channels/model.rs
@@ -161,6 +161,7 @@ auto_derived!(
         Icon,
         DefaultPermissions,
         Voice,
+        Slowmode,
     }
 );
 
@@ -554,6 +555,12 @@ impl Channel {
                 }
                 _ => {}
             },
+            FieldsChannel::Slowmode => match self {
+                Self::TextChannel { slowmode, .. } => {
+                    slowmode.take();
+                }
+                _ => {}
+            }
         }
     }
 
@@ -777,6 +784,7 @@ impl IntoDocumentPath for FieldsChannel {
             FieldsChannel::Icon => "icon",
             FieldsChannel::DefaultPermissions => "default_permissions",
             FieldsChannel::Voice => "voice",
+            FieldsChannel::Slowmode => "slowmode",
         })
     }
 }

--- a/crates/core/database/src/util/bridge/v0.rs
+++ b/crates/core/database/src/util/bridge/v0.rs
@@ -319,6 +319,7 @@ impl From<FieldsChannel> for crate::FieldsChannel {
             FieldsChannel::Icon => crate::FieldsChannel::Icon,
             FieldsChannel::DefaultPermissions => crate::FieldsChannel::DefaultPermissions,
             FieldsChannel::Voice => crate::FieldsChannel::Voice,
+            FieldsChannel::Slowmode => crate::FieldsChannel::Slowmode,
         }
     }
 }
@@ -330,6 +331,7 @@ impl From<crate::FieldsChannel> for FieldsChannel {
             crate::FieldsChannel::Icon => FieldsChannel::Icon,
             crate::FieldsChannel::DefaultPermissions => FieldsChannel::DefaultPermissions,
             crate::FieldsChannel::Voice => FieldsChannel::Voice,
+            crate::FieldsChannel::Slowmode => FieldsChannel::Slowmode,
         }
     }
 }

--- a/crates/core/models/src/v0/channels.rs
+++ b/crates/core/models/src/v0/channels.rs
@@ -164,6 +164,7 @@ auto_derived!(
         Icon,
         DefaultPermissions,
         Voice,
+        Slowmode,
     }
 
     /// New webhook information

--- a/crates/delta/src/routes/channels/channel_edit.rs
+++ b/crates/delta/src/routes/channels/channel_edit.rs
@@ -221,6 +221,9 @@ pub async fn edit(
                     v0::FieldsChannel::Voice => {
                         voice.take();
                     }
+                    v0::FieldsChannel::Slowmode => {
+                        slowmode.take();
+                    }
                     _ => {}
                 }
             }


### PR DESCRIPTION
Allows removing slowmode via `remove`.

- `main` <!-- branch-stack -->
  - \#836 :point\_left:
