### PR TITLE
fix: presence key was incorrect after other related update

### DIFF
--- a/crates/core/presence/src/lib.rs
+++ b/crates/core/presence/src/lib.rs
@@ -4,7 +4,7 @@ extern crate log;
 use once_cell::sync::Lazy;
 use rand::Rng;
 use redis_kiss::{get_connection, AsyncCommands};
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::format};
 
 mod operations;
 use operations::{
@@ -87,7 +87,9 @@ async fn delete_session_internal(user_id: &str, session_id: u32, skip_region: bo
 /// Check whether a given user ID is online
 pub async fn is_online(user_id: &str) -> bool {
     if let Ok(mut conn) = get_connection().await {
-        conn.exists(user_id).await.unwrap_or(false)
+        conn.exists(format!("sessions:{user_id}"))
+            .await
+            .unwrap_or(false)
     } else {
         false
     }

--- a/crates/core/presence/src/lib.rs
+++ b/crates/core/presence/src/lib.rs
@@ -4,7 +4,7 @@ extern crate log;
 use once_cell::sync::Lazy;
 use rand::Rng;
 use redis_kiss::{get_connection, AsyncCommands};
-use std::{collections::HashSet, fmt::format};
+use std::collections::HashSet;
 
 mod operations;
 use operations::{


### PR DESCRIPTION
Signed-off-by: IAmTomahawkx <iamtomahawkx@gmail.com>

<!-- Describe your changes -->

Fixes a problem with is\_online having the wrong redis key. This in turn caused pushd to believe that everyone was offline.

## How was this PR tested?

YOLO

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Nope

- `main` <!-- branch-stack -->
  - \#861 :point\_left:
