### PR TITLE
fix(database): omit empty MongoDB update operators

### DIFF
--- a/crates/core/database/src/drivers/mongodb.rs
+++ b/crates/core/database/src/drivers/mongodb.rs
@@ -157,14 +157,26 @@ impl MongoDb {
             }
         }
 
-        let query = doc! {
-            "$unset": unset,
-            "$set": if let Some(prefix) = &prefix {
-                to_document(&prefix_keys(&partial, prefix))
-            } else {
-                to_document(&partial)
-            }?
-        };
+        let set = if let Some(prefix) = &prefix {
+            to_document(&prefix_keys(&partial, prefix))
+        } else {
+            to_document(&partial)
+        }?;
+
+        // MongoDB rejects update documents where an operator (e.g. $set)
+        // is present but empty, so only include the operators we actually
+        // have data for.
+        let mut query = doc! {};
+        if !unset.is_empty() {
+            query.insert("$unset", unset);
+        }
+        if !set.is_empty() {
+            query.insert("$set", set);
+        }
+
+        if query.is_empty() {
+            return Ok(UpdateResult::default());
+        }
 
         self.col::<Document>(collection)
             .update_one(projection, query)

--- a/crates/core/database/src/models/users/model.rs
+++ b/crates/core/database/src/models/users/model.rs
@@ -990,4 +990,63 @@ mod tests {
             assert!(updated_invalid_update_result.is_err());
         });
     }
+
+    #[tokio::test]
+    async fn remove_profile_background() {
+        use crate::{FieldsUser, File, Metadata, PartialUser, UserProfile};
+
+        database_test!(|db| async move {
+            let mut user = User::create(&db, "Test".to_string(), None, None)
+                .await
+                .unwrap();
+
+            let background = File {
+                id: "banner_id".to_string(),
+                tag: "banners".to_string(),
+                filename: "banner.png".to_string(),
+                hash: None,
+                uploaded_at: None,
+                uploader_id: Some(user.id.clone()),
+                used_for: None,
+                deleted: None,
+                reported: None,
+                metadata: Metadata::Image {
+                    width: 100,
+                    height: 100,
+                    thumbhash: None,
+                    animated: None,
+                },
+                content_type: "image/png".to_string(),
+                size: 1,
+                message_id: None,
+                user_id: None,
+                server_id: None,
+                object_id: None,
+            };
+
+            user.update(
+                &db,
+                PartialUser {
+                    profile: Some(UserProfile {
+                        background: Some(background),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                vec![],
+            )
+            .await
+            .unwrap();
+
+            assert!(user.profile.as_ref().unwrap().background.is_some());
+
+            // Removing the banner without any other field changes used to
+            // send MongoDB an empty $set, which it rejects outright.
+            user.update(&db, PartialUser::default(), vec![FieldsUser::ProfileBackground])
+                .await
+                .unwrap();
+
+            assert!(user.profile.as_ref().unwrap().background.is_none());
+        });
+    }
 }


### PR DESCRIPTION
## Summary

MongoDB rejects update documents that include an empty `$set` operator. Removing a profile banner with no other profile field updates built `$set: {}` and returned a 500 `DatabaseError`.

`User::update` now only includes `$set` / `$unset` when they have fields, so an unset-only banner removal is a valid update.

Fixes #871

## How was this PR tested?

- [x] `cargo check -p revolt-database` passes
- [x] Added `remove_profile_background` regression test (unset-only path) and confirmed it compiles with the crate
- [ ] Full MongoDB integration suite (`TEST_DB=MONGODB`) — needs docker services via `mise docker:start` (not run locally)

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Assisted by AI (Grok / Cursor) for drafting the empty-operator guard and regression test; the fix and test were reviewed and adjusted by a human before submission.