### PR TITLE
Fix: Prefer first instance of a meta property in create_website_embed

### DIFF
--- a/crates/services/january/src/website_embed.rs
+++ b/crates/services/january/src/website_embed.rs
@@ -25,7 +25,8 @@ pub async fn create_website_embed(original_url: &str, document: &str) -> Option<
                 node.attr("property").or_else(|| node.attr("name")),
                 node.attr("content"),
             ) {
-                meta.insert(property.to_string(), content.to_string());
+                meta.entry(property.to_string())
+                    .or_insert(content.to_string());
             }
         }
 


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes #782 

By using a HashMap, the function was overwriting each property as it processed the document in the event that multiple meta tags had the same key. But the documentation I found indicated that in event of a conflict, the first property with a given key is meant to be used:

> [Arrays](https://ogp.me/#array)
> 
> If a tag can have multiple values, just put multiple versions of the same <meta> tag on your page. The first tag (from top to bottom) is given preference during conflicts.
> 
> <meta property="og:image" content="https://example.com/rock.jpg" />
> <meta property="og:image" content="https://example.com/rock2.jpg" />

The [HashMap documentation](https://doc.rust-lang.org/std/collections/struct.HashMap.html#entry-api) supplied the fix, honestly.

As a note, there's a bit more to the Arrays documentation:

> Whenever another root element is parsed, that structured property is considered to be done and another one is started.

...which this does not fix. This is actually already a bug in the code. If a website doesn't uniformly define `og:imagewidth` and `og:image:height` for either every or none of the `og:image` tags, neither the existing code nor this PR will be able to handle that correctly and the image may be given the wrong size. In the interest of keeping this simple, I haven't attempted to fix that.

## How was this PR tested?

<!-- What did you do to test your changes? -->

I wrote a short test with a simple HTML "head" section to make sure the URL from the first `og:image` tag was captured as the image URL. I didn't think it was adding much here and a regression seemed unlikely, so I removed it before committing.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None.
<!-- I deal with more than enough of those at my day job -->