### PR TITLE
fix: pin maildev version to 2.2.1

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -70,7 +70,7 @@ services:
 
   # Mock SMTP server
   maildev:
-    image: maildev/maildev
+    image: maildev/maildev:2.2.1
     ports:
       - "14025:25"
       - "14080:8080"


### PR DESCRIPTION
<!-- Describe your changes -->

Tests have been failing since maildev:latest jumped to a 3.x RC at the start of July.

https://hub.docker.com/r/maildev/maildev/tags

## How was this PR tested?

<!-- What did you do to test your changes? -->

`mise test` shows that all the previously failing SMTP tests seem to now be passing.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None