### PR TITLE
feat: permissions to block external emojis

### DIFF
--- a/crates/core/database/src/models/admin_migrations/ops/mongodb/scripts.rs
+++ b/crates/core/database/src/models/admin_migrations/ops/mongodb/scripts.rs
@@ -26,7 +26,7 @@ struct MigrationInfo {
     revision: i32,
 }
 
-pub const LATEST_REVISION: i32 = 52; // MUST BE +1 to last migration
+pub const LATEST_REVISION: i32 = 53; // MUST BE +1 to last migration
 
 pub async fn migrate_database(db: &MongoDb) {
     let migrations = db.col::<Document>("migrations");
@@ -1527,6 +1527,24 @@ pub async fn run_migrations(db: &MongoDb, revision: i32) -> i32 {
             })
             .await
             .expect("Failed to create audit_logs index");
+    };
+
+    if revision <= 52 {
+        info!("Running migration [revision 52 / 14-08-2026]: Add UseExternalEmojis to default permissions");
+
+        db.col::<Document>("servers")
+            .update_many(
+                doc! {},
+                doc! {
+                "$bit": {
+                    "default_permissions": {
+                        "or": ChannelPermission::UseExternalEmojis as i64
+                    },
+                },
+            },
+            )
+            .await
+            .expect("Failed to update default_permissions");
     };
 
     // Reminder to update LATEST_REVISION when adding new migrations.

--- a/crates/core/database/src/models/emojis/ops.rs
+++ b/crates/core/database/src/models/emojis/ops.rs
@@ -1,6 +1,6 @@
 use revolt_result::Result;
 
-use crate::{Emoji, PartialEmoji};
+use crate::{query, Emoji, PartialEmoji};
 
 #[cfg(feature = "mongodb")]
 mod mongodb;
@@ -13,6 +13,9 @@ pub trait AbstractEmojis: Sync + Send {
 
     /// Fetch an emoji by its id
     async fn fetch_emoji(&self, id: &str) -> Result<Emoji>;
+
+    /// Fetch emoji by their ids
+    async fn fetch_emojis(&self, ids: &[String]) -> Result<Vec<Emoji>>;
 
     /// Fetch emoji by their parent id
     async fn fetch_emoji_by_parent_id(&self, parent_id: &str) -> Result<Vec<Emoji>>;

--- a/crates/core/database/src/models/emojis/ops/mongodb.rs
+++ b/crates/core/database/src/models/emojis/ops/mongodb.rs
@@ -20,6 +20,20 @@ impl AbstractEmojis for MongoDb {
         query!(self, find_one_by_id, COL, id)?.ok_or_else(|| create_error!(NotFound))
     }
 
+    /// Fetch emoji by their ids
+    async fn fetch_emojis(&self, ids: &[String]) -> Result<Vec<Emoji>> {
+        query!(
+        self,
+        find,
+        COL,
+        doc! {
+            "_id": {
+                "$in": ids
+            }
+        }
+    )
+    }
+
     /// Fetch emoji by their parent id
     async fn fetch_emoji_by_parent_id(&self, parent_id: &str) -> Result<Vec<Emoji>> {
         query!(

--- a/crates/core/database/src/models/emojis/ops/reference.rs
+++ b/crates/core/database/src/models/emojis/ops/reference.rs
@@ -28,6 +28,15 @@ impl AbstractEmojis for ReferenceDb {
             .ok_or_else(|| create_error!(NotFound))
     }
 
+    async fn fetch_emojis(&self, ids: &[String]) -> Result<Vec<Emoji>> {
+        let emojis = self.emojis.lock().await;
+        Ok(emojis
+            .values()
+            .filter(|emoji| ids.contains(&emoji.id))
+            .cloned()
+            .collect())
+    }
+
     /// Fetch emoji by their parent id
     async fn fetch_emoji_by_parent_id(&self, parent_id: &str) -> Result<Vec<Emoji>> {
         let emojis = self.emojis.lock().await;

--- a/crates/core/database/src/models/messages/model.rs
+++ b/crates/core/database/src/models/messages/model.rs
@@ -12,14 +12,10 @@ use std::{collections::HashSet, hash::RandomState};
 use ulid::Ulid;
 use validator::Validate;
 
-use crate::{
-    events::client::EventV1,
-    util::{
-        bulk_permissions::BulkDatabasePermissionQuery, idempotency::IdempotencyKey,
-        permissions::DatabasePermissionQuery,
-    },
-    Channel, Database, Emoji, File, User, AMQP,
-};
+use crate::{events::client::EventV1, util::{
+    bulk_permissions::BulkDatabasePermissionQuery, idempotency::IdempotencyKey,
+    permissions::DatabasePermissionQuery,
+}, Channel, Database, Emoji, EmojiParent, File, User, AMQP};
 
 #[cfg(feature = "tasks")]
 use crate::tasks::{self, ack::AckEvent};
@@ -388,12 +384,13 @@ impl Message {
             mut role_mentions,
             mut mentions_everyone,
             mut mentions_online,
+            emojis,
             ..
         } = message_mentions;
 
         if allow_mass_mentions && server_id.is_some() && !role_mentions.is_empty() {
             let server_data = db
-                .fetch_server(server_id.unwrap().as_str())
+                .fetch_server(server_id.as_ref().unwrap().as_str())
                 .await
                 .expect("Failed to fetch server");
 
@@ -529,6 +526,39 @@ impl Message {
                 }
                 Channel::SavedMessages { .. } => {
                     user_mentions.clear();
+                }
+            }
+        }
+
+        // Validate external emoji usage
+        if !emojis.is_empty() {
+            if let Some(server_id) = &server_id {
+                let emoji_ids: Vec<String> = emojis.iter().cloned().collect();
+                let resolved = db.fetch_emojis(&emoji_ids).await.map_err(|e| {
+                    revolt_config::capture_error(&e);
+                    create_error!(InternalError)
+                })?;
+
+                let foreign: Vec<&Emoji> = resolved
+                    .iter()
+                    .filter(|e: &&Emoji| match &e.parent {
+                        EmojiParent::Server { id } => id != server_id,
+                        EmojiParent::Detached => false,
+                    })
+                    .collect();
+
+                if !foreign.is_empty() {
+                    if let MessageAuthor::User(user) = &author {
+                        let owned_user: User = (*user).clone().into();
+                        let mut query = DatabasePermissionQuery::new(db, &owned_user).channel(&channel);
+                        let perms = calculate_channel_permissions(&mut query).await;
+
+                        if !perms.has_channel_permission(ChannelPermission::UseExternalEmojis) {
+                            return Err(create_error!(MissingPermission {
+                        permission: ChannelPermission::UseExternalEmojis.to_string()
+                    }));
+                        }
+                    }
                 }
             }
         }

--- a/crates/core/database/src/models/messages/model.rs
+++ b/crates/core/database/src/models/messages/model.rs
@@ -548,8 +548,8 @@ impl Message {
                     .collect();
 
                 if !foreign.is_empty() {
-                    if let MessageAuthor::User(user) = &author {
-                        let owned_user: User = (*user).clone().into();
+                    if let MessageAuthor::User(user) = author {
+                        let owned_user: User = user.clone().into();
                         let mut query = DatabasePermissionQuery::new(db, &owned_user).channel(&channel);
                         let perms = calculate_channel_permissions(&mut query).await;
 

--- a/crates/core/database/src/models/messages/model.rs
+++ b/crates/core/database/src/models/messages/model.rs
@@ -536,7 +536,7 @@ impl Message {
                 let emoji_ids: Vec<String> = emojis.iter().cloned().collect();
                 let resolved = db.fetch_emojis(&emoji_ids).await.map_err(|e| {
                     revolt_config::capture_error(&e);
-                    create_error!(InternalError)
+                    create_database_error!("find", "emojis")
                 })?;
 
                 let foreign: Vec<&Emoji> = resolved

--- a/crates/core/permissions/src/models/channel.rs
+++ b/crates/core/permissions/src/models/channel.rs
@@ -31,6 +31,8 @@ pub enum ChannelPermission {
     ManageRole = 1 << 3,
     /// Manage server customisation (includes emoji)
     ManageCustomisation = 1 << 4,
+    /// Allow external emoji usage
+    UseExternalEmojis = 1 << 41,
 
     // % 1 bit reserved
 
@@ -104,7 +106,7 @@ pub enum ChannelPermission {
     ViewAuditLogs = 1 << 40,
 
     // * Misc. permissions
-    // % Bits 41 to 52: free area
+    // % Bits 42 to 52: free area
     // % Bits 53 to 64: do not use
 
     // * Grant all permissions
@@ -153,7 +155,8 @@ pub static DEFAULT_PERMISSION_SERVER: Lazy<u64> = Lazy::new(|| {
     DEFAULT_PERMISSION.add(
         ChannelPermission::React
             + ChannelPermission::ChangeNickname
-            + ChannelPermission::ChangeAvatar,
+            + ChannelPermission::ChangeAvatar
+            + ChannelPermission::UseExternalEmojis,
     )
 });
 


### PR DESCRIPTION
<!-- Describe your changes -->

Servers now can choose to block external emojis, emojis sent to a server that is not from the server will be blocked if this permission is not allowed.

- Add `UseExternalEmojis (1 <<41)` as a new permission
- Emojis must be valid emojis to get blocked
- Migration script that adds all the servers the permission by default

Fixes # (issue)

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] Sent an emoji without running the migration script, got MissingPermissions as expected
- [x] Ran the migration script and was able to send emojis
- [x] Made an API call to disallow the permission and was not able to send messages again

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Artifical Ispik delivers new PRs so Tom doesn't review it (No AI used)

- `main` <!-- branch-stack -->
  - \#926 :point\_left:
