### PR TITLE
chore: remove build info and rename revolt -> stoat

### DIFF
--- a/crates/delta/src/routes/root.rs
+++ b/crates/delta/src/routes/root.rs
@@ -153,27 +153,12 @@ impl UserLimits {
     }
 }
 
-/// # Build Information
-#[derive(Serialize, JsonSchema, Debug)]
-pub struct BuildInformation {
-    /// Commit Hash
-    pub commit_sha: String,
-    /// Commit Timestamp
-    pub commit_timestamp: String,
-    /// Git Semver
-    pub semver: String,
-    /// Git Origin URL
-    pub origin_url: String,
-    /// Build Timestamp
-    pub timestamp: String,
-}
-
 /// # Server Configuration
 #[derive(Serialize, JsonSchema, Debug)]
 pub struct RevoltConfig {
-    /// Revolt API Version
-    pub revolt: String,
-    /// Features enabled on this Revolt node
+    /// Stoat API Version
+    pub stoat: String,
+    /// Features enabled on this Stoat node
     pub features: RevoltFeatures,
     /// WebSocket URL
     pub ws: String,
@@ -181,8 +166,6 @@ pub struct RevoltConfig {
     pub app: String,
     /// Web Push VAPID public key
     pub vapid: String,
-    /// Build information
-    pub build: BuildInformation,
 }
 
 /// # Query Node
@@ -194,7 +177,7 @@ pub async fn root() -> Result<Json<RevoltConfig>> {
     let config = config().await;
 
     Ok(Json(RevoltConfig {
-        revolt: env!("CARGO_PKG_VERSION").to_string(),
+        stoat: env!("CARGO_PKG_VERSION").to_string(),
         features: RevoltFeatures {
             captcha: CaptchaFeature {
                 enabled: !config.api.security.captcha.hcaptcha_key.is_empty(),
@@ -260,23 +243,6 @@ pub async fn root() -> Result<Json<RevoltConfig>> {
         ws: config.hosts.events,
         app: config.hosts.app,
         vapid: config.pushd.vapid.public_key,
-        build: BuildInformation {
-            commit_sha: option_env!("VERGEN_GIT_SHA")
-                .unwrap_or_else(|| "<failed to generate>")
-                .to_string(),
-            commit_timestamp: option_env!("VERGEN_GIT_COMMIT_TIMESTAMP")
-                .unwrap_or_else(|| "<failed to generate>")
-                .to_string(),
-            semver: option_env!("VERGEN_GIT_SEMVER")
-                .unwrap_or_else(|| "<failed to generate>")
-                .to_string(),
-            origin_url: option_env!("GIT_ORIGIN_URL")
-                .unwrap_or_else(|| "<failed to generate>")
-                .to_string(),
-            timestamp: option_env!("VERGEN_BUILD_TIMESTAMP")
-                .unwrap_or_else(|| "<failed to generate>")
-                .to_string(),
-        },
     }))
 }
 


### PR DESCRIPTION
<!-- Describe your changes -->

Remove build info since it was never generated anyways. Also renamed revolt -> stoat in the root payload.

To be merged for 0.16.0

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

N/A

- `main` <!-- branch-stack -->
  - \#928 :point\_left:
