### PR TITLE
fix: Make SuppressNotifications actually suppress notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ venv/
 
 livekit.yml
 .idea
+.vscode/launch.json

--- a/crates/core/database/src/models/messages/model.rs
+++ b/crates/core/database/src/models/messages/model.rs
@@ -693,6 +693,8 @@ impl Message {
             Channel::DirectMessage { .. } | Channel::Group { .. }
         );
 
+        let suppressed = self.has_suppressed_notifications();
+
         if !self.has_suppressed_notifications()
             && (is_dm_or_group || self.mentions.is_some() || self.contains_mass_push_mention())
         {
@@ -760,8 +762,7 @@ impl Message {
     /// Whether this message has suppressed notifications
     pub fn has_suppressed_notifications(&self) -> bool {
         if let Some(flags) = self.flags {
-            flags & MessageFlags::SuppressNotifications as u32
-                == MessageFlags::SuppressNotifications as u32
+            MessageFlagsValue(flags).has(MessageFlags::SuppressNotifications)
         } else {
             false
         }
@@ -769,8 +770,7 @@ impl Message {
 
     pub fn contains_mass_push_mention(&self) -> bool {
         let ping = if let Some(flags) = self.flags {
-            let flags = MessageFlagsValue(flags);
-            flags.has(MessageFlags::MentionsEveryone)
+            MessageFlagsValue(flags).has(MessageFlags::MentionsEveryone)
         } else {
             false
         };

--- a/crates/core/database/src/models/messages/model.rs
+++ b/crates/core/database/src/models/messages/model.rs
@@ -693,8 +693,6 @@ impl Message {
             Channel::DirectMessage { .. } | Channel::Group { .. }
         );
 
-        let suppressed = self.has_suppressed_notifications();
-
         if !self.has_suppressed_notifications()
             && (is_dm_or_group || self.mentions.is_some() || self.contains_mass_push_mention())
         {


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes an issue where the suppressnotifications flag wouldn't be read correctly in Message.has\_suppressed\_notifications

## How was this PR tested?

<!-- What did you do to test your changes? -->

Ran it locally and stepped through with a debugger.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

N/A

- `main` <!-- branch-stack -->
  - \#931 :point\_left:
