### PR TITLE
fix: reduce test parallelism to fix flaky event tests

### DIFF
--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -5,4 +5,7 @@ set -e
 : "${TEST_DB:=REFERENCE}"
 export TEST_DB
 
+: "${NEXTEST_TEST_THREADS:=4}"
+export NEXTEST_TEST_THREADS
+
 cargo nextest run


### PR DESCRIPTION
<!-- Describe your changes -->

This branch aims to fix the issue where some tests relying on pub/sub events fail in CI test runs, seemingly depending on how quickly they are run together. My theory is that some part of the system (likely KeyDB) is getting overwhelmed with events. Reducing how many tests can be run in parallel seems to fix this behaviour. There are likely better ways to resolve this (particularly based on the warning in the test harness code before the "unreachable" statement), but I may have to leave those to somebody cleverer than myself.

## How was this PR tested?

<!-- What did you do to test your changes? -->

To be perfectly honest I just kept running it again and again and watched to see how many threads I could use without encountering any event-based test failures. 4 allows the tests to complete in a reasonable amount of time without producing any nonsense.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None
