### PR TITLE
fix: audit log test failures when events sort out-of-order

### DIFF
--- a/crates/delta/src/routes/servers/audit_log_query.rs
+++ b/crates/delta/src/routes/servers/audit_log_query.rs
@@ -171,7 +171,10 @@ mod test {
 
         assert_eq!(&users[0].id, &user.id);
 
-        let entry = &entries[0];
+        let entry = entries
+            .iter()
+            .find(|entry| entry.reason.as_deref() == Some("Test Reason 3"))
+            .expect("Missing channel deletion audit record");
 
         assert_eq!(entry.reason.as_deref(), Some("Test Reason 3"));
         assert_eq!(&entry.server, &server.id);
@@ -184,7 +187,10 @@ mod test {
             }
         );
 
-        let entry = &entries[1];
+        let entry = entries
+            .iter()
+            .find(|entry| entry.reason.as_deref() == Some("Test Reason 2"))
+            .expect("Missing channel description edit audit record");
 
         assert_eq!(entry.reason.as_deref(), Some("Test Reason 2"));
         assert_eq!(&entry.server, &server.id);
@@ -204,7 +210,10 @@ mod test {
             }
         );
 
-        let entry = &entries[2];
+        let entry = entries
+            .iter()
+            .find(|entry| entry.reason.as_deref() == Some("Test Reason 1"))
+            .expect("Missing channel edit audit record");
 
         assert_eq!(entry.reason.as_deref(), Some("Test Reason 1"));
         assert_eq!(&entry.server, &server.id);


### PR DESCRIPTION
<!-- Describe your changes -->

While working through #932, I also found that the audit log query tests sometimes want to sort out of order if they arrive too close together.

I understand from the ULID spec that we can really only guarantee audit log order if the IDs aren't generated in the same millisecond. So, this was solvable by sleeping for a millisecond between each audited event, but it seemed less fragile to simply select the exact entry we want to prove the existence of for each round of assertions.

## How was this PR tested?

<!-- What did you do to test your changes? -->

- Ran the tests with a 1 millisecond sleep between each audited event
- Ran the tests with the slightly ugly `.find()` logic to select the correct entry

Either worked, but the latter didn't introduce a weirdly inexplicable sleep call.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

None.