### PR TITLE
fix: store ratelimits in redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7556,8 +7556,8 @@ version = "0.15.1"
 dependencies = [
  "async-trait",
  "axum",
- "dashmap",
  "log",
+ "redis-kiss",
  "revolt-config",
  "revolt-database",
  "revolt-result",

--- a/crates/core/ratelimits/Cargo.toml
+++ b/crates/core/ratelimits/Cargo.toml
@@ -27,7 +27,8 @@ revolt_rocket_okapi = { workspace = true, optional = true }
 
 axum = { workspace = true, optional = true, features = ["macros"] }
 
+redis-kiss = { workspace = true }
+
 serde = { workspace = true }
-dashmap = { workspace = true }
 async-trait = { workspace = true }
 log = { workspace = true }

--- a/crates/core/ratelimits/src/axum.rs
+++ b/crates/core/ratelimits/src/axum.rs
@@ -47,7 +47,7 @@ where
             let limit = storage.resolver.resolve_bucket_limit(bucket);
 
             let ratelimiter =
-                Ratelimiter::from(&storage.map, &identifier, limit, (bucket, resource));
+                Ratelimiter::from(&identifier, limit, (bucket, resource)).await;
 
             parts.extensions.insert(ratelimiter.map_err(Json));
         };

--- a/crates/core/ratelimits/src/ratelimiter.rs
+++ b/crates/core/ratelimits/src/ratelimiter.rs
@@ -4,9 +4,13 @@ use std::ops::Add;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use redis_kiss::redis::ExistenceCheck;
+use redis_kiss::{
+    get_connection,
+    redis::{Pipeline, SetExpiry, SetOptions, aio::Connection},
+};
+use revolt_result::ToRevoltError;
 use serde::Serialize;
-
-use dashmap::DashMap;
 
 pub trait RequestKind {
     type R<'a>;
@@ -20,14 +24,12 @@ pub trait RatelimitResolver<R>: Send + Sync {
 #[derive(Clone)]
 pub struct RatelimitStorage<K: RequestKind> {
     pub resolver: Arc<dyn for<'a> RatelimitResolver<K::R<'a>>>,
-    pub map: Arc<DashMap<u64, Entry>>,
 }
 
 impl<K: RequestKind> RatelimitStorage<K> {
     pub fn new<R: for<'a> RatelimitResolver<K::R<'a>> + 'static>(resolver: R) -> Self {
         Self {
             resolver: Arc::new(resolver),
-            map: Arc::new(DashMap::new()),
         }
     }
 }
@@ -47,42 +49,60 @@ fn now() -> Duration {
 }
 
 impl Entry {
-    /// Find bucket by its key
-    pub fn from(map: &DashMap<u64, Entry>, key: u64) -> Entry {
-        map.get(&key).map(|x| *x).unwrap_or_else(|| Entry {
-            used: 0,
-            reset: now().add(Duration::from_secs(10)).as_millis(),
-        })
+    /// Find bucket by its key, and incremement its usage count
+    pub async fn from(conn: &mut Connection, now: Duration, key: u64) -> Entry {
+        let expire = now.add(Duration::from_secs(10)).as_millis();
+
+        let (used, _, reset) = Pipeline::new()
+            .incr(format!("rl:{key}:used"), 1)
+            .set_options(
+                format!("rl:{key}:reset"),
+                expire as usize,
+                SetOptions::default()
+                    .conditional_set(ExistenceCheck::NX)
+                    .with_expiration(SetExpiry::EX(10)),
+            )
+            .get(format!("rl:{key}:reset"))
+            .query_async::<_, (u32, (), u128)>(conn)
+            .await
+            .ok()
+            .unwrap_or((1, (), expire));
+
+        Entry { used, reset }
     }
 
-    /// Deduct one unit from the bucket and save
-    pub fn deduct(&mut self) {
-        let current_time = now().as_millis();
+    /// Check if the entry is expired, and reset it if so
+    pub fn is_expired(&mut self, now: Duration) {
+        let current_time = now.as_millis();
+
         if current_time > self.reset {
             self.used = 1;
-            self.reset = now().add(Duration::from_secs(10)).as_millis();
-        } else {
-            self.used += 1;
-        }
+            self.reset = now.add(Duration::from_secs(10)).as_millis();
+        };
     }
 
     /// Save information
-    pub fn save(self, map: &DashMap<u64, Entry>, key: u64) {
-        map.insert(key, self);
+    pub async fn save(self, conn: &mut Connection, key: u64) {
+        let _ = Pipeline::new()
+            .pexpire_at(format!("rl:{key}:used"), self.reset as usize)
+            .pexpire_at(format!("rl:{key}:reset"), self.reset as usize)
+            .query_async::<_, ()>(conn)
+            .await
+            .to_internal_error();
     }
 
     /// Get remaining units in the bucket
-    pub fn get_remaining(&self, limit: u32) -> u32 {
-        if now().as_millis() > self.reset {
+    pub fn get_remaining(&self, now: Duration, limit: u32) -> u32 {
+        if now.as_millis() > self.reset {
             limit
         } else {
-            limit - self.used
+            (limit + 1).saturating_sub(self.used)
         }
     }
 
     /// Get how long bucket has until reset
-    pub fn left_until_reset(&self) -> u128 {
-        let current_time = now().as_millis();
+    pub fn left_until_reset(&self, now: Duration) -> u128 {
+        let current_time = now.as_millis();
         self.reset.saturating_sub(current_time)
     }
 }
@@ -99,8 +119,7 @@ pub struct Ratelimiter {
 
 impl Ratelimiter {
     /// Generate guard from identifier and target bucket
-    pub fn from(
-        map: &DashMap<u64, Entry>,
+    pub async fn from(
         identifier: &str,
         limit: u32,
         (bucket, resource): (&str, Option<&str>),
@@ -114,10 +133,16 @@ impl Ratelimiter {
         }
 
         let key = key.finish();
-        let mut entry = Entry::from(map, key);
+        let mut conn = get_connection()
+            .await
+            .expect("Failed to get redis connection")
+            .into_inner();
 
-        let remaining = entry.get_remaining(limit);
-        let reset = entry.left_until_reset();
+        let now = now();
+        let mut entry = Entry::from(&mut conn, now, key).await;
+
+        let remaining = entry.get_remaining(now, limit);
+        let reset = entry.left_until_reset(now);
         let mut ratelimiter = Ratelimiter {
             key,
             limit,
@@ -128,10 +153,10 @@ impl Ratelimiter {
             return Err(ratelimiter);
         }
 
-        entry.deduct();
-        entry.save(map, key);
+        entry.is_expired(now);
+        entry.save(&mut conn, key).await;
         ratelimiter.remaining -= 1;
-        ratelimiter.reset = entry.left_until_reset();
+        ratelimiter.reset = entry.left_until_reset(now);
 
         Ok(ratelimiter)
     }

--- a/crates/core/ratelimits/src/ratelimiter.rs
+++ b/crates/core/ratelimits/src/ratelimiter.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
 use std::ops::Add;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use redis_kiss::redis::ExistenceCheck;
@@ -11,6 +11,8 @@ use redis_kiss::{
 };
 use revolt_result::ToRevoltError;
 use serde::Serialize;
+
+static IS_TEST_ENV: LazyLock<bool> = LazyLock::new(|| std::env::var("TEST_DB").is_ok());
 
 pub trait RequestKind {
     type R<'a>;
@@ -133,6 +135,16 @@ impl Ratelimiter {
         }
 
         let key = key.finish();
+
+        if *IS_TEST_ENV {
+            return Ok(Ratelimiter {
+                key,
+                limit,
+                remaining: limit,
+                reset: 10000,
+            });
+        }
+
         let mut conn = get_connection()
             .await
             .expect("Failed to get redis connection")
@@ -156,7 +168,6 @@ impl Ratelimiter {
         entry.is_expired(now);
         entry.save(&mut conn, key).await;
         ratelimiter.remaining -= 1;
-        ratelimiter.reset = entry.left_until_reset(now);
 
         Ok(ratelimiter)
     }

--- a/crates/core/ratelimits/src/rocket.rs
+++ b/crates/core/ratelimits/src/rocket.rs
@@ -44,7 +44,7 @@ impl<'r> FromRequest<'r> for Ratelimiter {
                 let (bucket, resource) = storage.resolver.resolve_bucket(request);
                 let limit = storage.resolver.resolve_bucket_limit(bucket);
 
-                Ratelimiter::from(&storage.map, &identifier, limit, (bucket, resource))
+                Ratelimiter::from(&identifier, limit, (bucket, resource)).await
             })
             .await;
 

--- a/crates/delta/src/util/ratelimits.rs
+++ b/crates/delta/src/util/ratelimits.rs
@@ -54,10 +54,10 @@ impl<'a> RatelimitResolver<Request<'a>> for DeltaRatelimits {
                 ("swagger", _, _) => ("swagger", None),
                 ("safety", Some("report"), _) => ("safety_report", Some("report")),
                 ("safety", _, _) => ("safety", None),
-                _ => ("any", None),
+                _ => ("any_dlta", None),
             }
         } else {
-            ("any", None)
+            ("any_dlta", None)
         }
     }
 

--- a/crates/delta/src/util/ratelimits.rs
+++ b/crates/delta/src/util/ratelimits.rs
@@ -5,19 +5,11 @@ pub struct DeltaRatelimits;
 
 impl<'a> RatelimitResolver<Request<'a>> for DeltaRatelimits {
     fn resolve_bucket<'r>(&self, request: &'r Request<'_>) -> (&'r str, Option<&'r str>) {
-        let (segment, resource, extra) = if request.routed_segment(0) == Some("0.8") {
-            (
-                request.routed_segment(1),
-                request.routed_segment(2),
-                request.routed_segment(3),
-            )
-        } else {
-            (
-                request.routed_segment(0),
-                request.routed_segment(1),
-                request.routed_segment(2),
-            )
-        };
+        let (segment, resource, extra) = (
+            request.routed_segment(0),
+            request.routed_segment(1),
+            request.routed_segment(2),
+        );
 
         if let Some(segment) = segment {
             #[allow(clippy::redundant_locals)]

--- a/crates/services/autumn/src/ratelimits.rs
+++ b/crates/services/autumn/src/ratelimits.rs
@@ -14,15 +14,14 @@ impl RatelimitResolver<Parts> for AutumnRatelimits {
 
         match (&parts.method, path.as_slice()) {
             (&Method::POST, &[tag]) => ("upload", Some(tag)),
-            _ => ("any", None),
+            _ => ("any_atmn", None),
         }
     }
 
     fn resolve_bucket_limit(&self, bucket: &str) -> u32 {
         match bucket {
             "upload" => 10,
-            "any" => u32::MAX,
-            _ => unreachable!("Bucket defined but no limit set"),
+            _ => u32::MAX,
         }
     }
 }

--- a/crates/services/gifbox/src/ratelimits.rs
+++ b/crates/services/gifbox/src/ratelimits.rs
@@ -16,7 +16,7 @@ impl RatelimitResolver<Parts> for GifboxRatelimits {
             Some("categories") => ("categories", None),
             Some("trending") => ("trending", None),
             Some("search") => ("search", None),
-            _ => ("any", None),
+            _ => ("any_gfbx", None),
         }
     }
 
@@ -25,8 +25,7 @@ impl RatelimitResolver<Parts> for GifboxRatelimits {
             "categories" => 2,
             "trending" => 5,
             "search" => 10,
-            "any" => u32::MAX,
-            _ => unreachable!("Bucket defined but no limit set"),
+            _ => u32::MAX,
         }
     }
 }


### PR DESCRIPTION
Fixes ratelimits being separate per node.

- `main` <!-- branch-stack -->
  - \#934 :point\_left:
