### PR TITLE
fix: send relationship info for bots

### DIFF
--- a/crates/core/database/src/util/bridge/v0.rs
+++ b/crates/core/database/src/util/bridge/v0.rs
@@ -1005,9 +1005,7 @@ impl crate::User {
         P: Into<Option<&'a crate::User>>,
     {
         let perspective = perspective.into();
-        let (relationship, can_see_profile) = if self.bot.is_some() {
-            (RelationshipStatus::None, true)
-        } else if let Some(perspective) = perspective {
+        let (relationship, can_see_profile) = if let Some(perspective) = perspective {
             let mut query = DatabasePermissionQuery::new(db, perspective).user(&self);
 
             if perspective.id == self.id {
@@ -1086,9 +1084,7 @@ impl crate::User {
         P: Into<Option<&'a crate::User>>,
     {
         let perspective = perspective.into();
-        let (relationship, can_see_profile) = if self.bot.is_some() {
-            (RelationshipStatus::None, true)
-        } else if let Some(perspective) = perspective {
+        let (relationship, can_see_profile) = if let Some(perspective) = perspective {
             if perspective.id == self.id {
                 (RelationshipStatus::User, true)
             } else {

--- a/crates/core/permissions/src/impl.rs
+++ b/crates/core/permissions/src/impl.rs
@@ -6,11 +6,7 @@ use crate::{
 
 /// Calculate permissions against a user
 pub async fn calculate_user_permissions<P: PermissionQuery>(query: &mut P) -> PermissionValue {
-    if query.are_we_privileged().await {
-        return u64::MAX.into();
-    }
-
-    if query.are_the_users_same().await {
+    if query.are_we_privileged().await || query.are_the_users_same().await {
         return u64::MAX.into();
     }
 
@@ -26,17 +22,15 @@ pub async fn calculate_user_permissions<P: PermissionQuery>(query: &mut P) -> Pe
         _ => {}
     }
 
-    if query.have_mutual_connection().await {
+    if query.have_mutual_connection().await || query.user_is_bot().await {
         permissions = UserPermission::Access as u64 + UserPermission::ViewProfile as u64;
+    };
 
-        if query.user_is_bot().await || query.are_we_a_bot().await {
-            permissions += UserPermission::SendMessage as u64;
-        }
+    if query.have_mutual_connection().await && (query.are_we_a_bot().await || query.user_is_bot().await) {
+        permissions += UserPermission::SendMessage as u64;
+    };
 
-        permissions.into()
-    } else {
-        permissions.into()
-    }
+    permissions.into()
 
     // TODO: add boolean switch for permission for users to globally message a user
     // maybe an enum?

--- a/crates/delta/src/routes/users/block_user.rs
+++ b/crates/delta/src/routes/users/block_user.rs
@@ -1,7 +1,7 @@
 use revolt_database::util::reference::Reference;
 use revolt_database::{Database, User};
 use revolt_models::v0;
-use revolt_result::Result;
+use revolt_result::{create_error, Result};
 use rocket::serde::json::Json;
 use rocket::State;
 
@@ -15,6 +15,10 @@ pub async fn block(
     mut user: User,
     target: Reference<'_>,
 ) -> Result<Json<v0::User>> {
+    if user.bot.is_some() {
+        return Err(create_error!(IsBot));
+    }
+
     let mut target = target.as_user(db).await?;
 
     user.block_user(db, &mut target).await?;

--- a/crates/delta/src/routes/users/unblock_user.rs
+++ b/crates/delta/src/routes/users/unblock_user.rs
@@ -1,7 +1,7 @@
 use revolt_database::util::reference::Reference;
 use revolt_database::{Database, User};
 use revolt_models::v0;
-use revolt_result::Result;
+use revolt_result::{create_error, Result};
 use rocket::serde::json::Json;
 use rocket::State;
 
@@ -15,6 +15,10 @@ pub async fn unblock(
     mut user: User,
     target: Reference<'_>,
 ) -> Result<Json<v0::User>> {
+    if user.bot.is_some() {
+        return Err(create_error!(IsBot));
+    }
+
     let mut target = target.as_user(db).await?;
 
     user.unblock_user(db, &mut target).await?;


### PR DESCRIPTION
- send relationship info about bots - client can detect if you blocked a bot
- disallow bots from blocking
- always allow users to view bot's profile

* `main` <!-- branch-stack -->
  - \#935 :point\_left:
