### PR TITLE
feat: Interactive Components Library for Bots

### DIFF
--- a/stoat-components/.gitignore
+++ b/stoat-components/.gitignore
@@ -1,0 +1,13 @@
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+*.egg-info/
+dist/
+build/
+.eggs/
+*.egg
+.env

--- a/stoat-components/examples/buttons_example.py
+++ b/stoat-components/examples/buttons_example.py
@@ -1,0 +1,76 @@
+"""
+Example: Creating interactive buttons for a Stoat bot.
+"""
+
+import json
+from stoat_components import Button, ButtonStyle
+
+
+def create_action_row():
+    """Create a row with multiple buttons."""
+    confirm_btn = Button(
+        label="Confirmar",
+        style=ButtonStyle.SUCCESS,
+        custom_id="confirm_action",
+    )
+
+    cancel_btn = Button(
+        label="Cancelar",
+        style=ButtonStyle.DANGER,
+        custom_id="cancel_action",
+    )
+
+    link_btn = Button(
+        label="Documentação",
+        style=ButtonStyle.LINK,
+        url="https://stoat.dev/docs",
+    )
+
+    return {
+        "type": 1,
+        "components": [
+            confirm_btn.to_dict(),
+            cancel_btn.to_dict(),
+            link_btn.to_dict(),
+        ]
+    }
+
+
+def create_disabled_button():
+    """Example of a disabled button."""
+    btn = Button(
+        label="Indisponível",
+        style=ButtonStyle.SECONDARY,
+        custom_id="disabled_btn",
+        disabled=True,
+    )
+    return btn.to_dict()
+
+
+def create_button_with_callback():
+    """Example using callback decorator."""
+    btn = Button(
+        label="Clique Aqui",
+        style=ButtonStyle.PRIMARY,
+        custom_id="click_me",
+    )
+
+    @btn.callback
+    async def on_click(interaction):
+        print(f"Botão clicado por {interaction.user}")
+        await interaction.respond("Você clicou no botão!")
+
+    return btn
+
+
+if __name__ == "__main__":
+    row = create_action_row()
+    print("Action Row:")
+    print(json.dumps(row, indent=2, ensure_ascii=False))
+
+    print("\nDisabled Button:")
+    print(json.dumps(create_disabled_button(), indent=2, ensure_ascii=False))
+
+    print("\nButton with callback:")
+    btn = create_button_with_callback()
+    print(btn)

--- a/stoat-components/examples/select_menu_example.py
+++ b/stoat-components/examples/select_menu_example.py
@@ -1,0 +1,88 @@
+"""
+Example: Creating select menus for a Stoat bot.
+"""
+
+import json
+from stoat_components import SelectMenu, SelectOption
+
+
+def create_role_selector():
+    """Create a role selection menu."""
+    options = [
+        SelectOption(
+            label="Admin",
+            value="admin",
+            description="Acesso total ao servidor",
+        ),
+        SelectOption(
+            label="Moderador",
+            value="mod",
+            description="Permissoes de moderacao",
+        ),
+        SelectOption(
+            label="Membro",
+            value="member",
+            description="Membro padrao",
+        ),
+        SelectOption(
+            label="Visitante",
+            value="visitor",
+            description="Apenas visualizacao",
+        ),
+    ]
+
+    menu = SelectMenu(
+        custom_id="role_selector",
+        options=options,
+        placeholder="Selecione seu cargo...",
+        min_values=1,
+        max_values=1,
+    )
+    return menu
+
+
+def create_channel_selector():
+    """Create a multi-select channel menu."""
+    options = [
+        SelectOption(label="Geral", value="geral"),
+        SelectOption(label="Ajuda", value="ajuda"),
+        SelectOption(label="Off-Topic", value="offtopic"),
+    ]
+
+    menu = SelectMenu(
+        custom_id="channel_selector",
+        options=options,
+        placeholder="Selecione canais para acesso...",
+        min_values=1,
+        max_values=3,
+    )
+    return menu
+
+
+def create_disabled_menu():
+    """Example of a disabled select menu."""
+    options = [
+        SelectOption(label="Opcao 1", value="opt1"),
+    ]
+
+    menu = SelectMenu(
+        custom_id="disabled_menu",
+        options=options,
+        placeholder="Menu indisponivel",
+        disabled=True,
+    )
+    return menu
+
+
+if __name__ == "__main__":
+    print("Role Selector:")
+    role_menu = create_role_selector()
+    print(json.dumps(role_menu.to_dict(), indent=2, ensure_ascii=False))
+
+    print("\nChannel Selector (multi-select):")
+    channel_menu = create_channel_selector()
+    print(json.dumps(channel_menu.to_dict(), indent=2, ensure_ascii=False))
+
+    print("\nDisabled Menu:")
+    disabled_menu = create_disabled_menu()
+    print(json.dumps(disabled_menu.to_dict(), indent=2, ensure_ascii=False))

--- a/stoat-components/proposal/README.md
+++ b/stoat-components/proposal/README.md
@@ -1,0 +1,82 @@
+# Stoat Interactive Components - Proposal
+
+This proposal adds support for interactive components (buttons and select menus) for bots on Stoat.
+
+## Proposal Structure
+
+```
+proposal/
+├── README.md
+├── RFC_INTERACTIVE_COMPONENTS.md
+└── docs/
+    ├── interactive-components.md
+    └── implementation-guide.md
+```
+
+## Summary
+
+### What is it
+
+Interactive components are UI elements that allow users to interact with bot messages:
+
+- **Buttons**: Actions with different styles (primary, success, danger, link)
+- **Select Menus**: Dropdowns for option selection
+
+### Why
+
+- Bots need better ways to interact with users
+- Improves user experience
+- Compatible with industry standards (Discord, etc.)
+
+### How
+
+1. Add `components` to `DataMessageSend` schema
+2. Create `interaction_create` events
+3. Create interaction response endpoint
+
+## Files
+
+### [Full RFC](RFC_INTERACTIVE_COMPONENTS.md)
+
+Complete technical documentation including:
+- API schemas
+- Usage examples
+- Events and responses
+- Limits
+
+### [Developer Documentation](docs/interactive-components.md)
+
+Documentation that can be added to the Stoat docs site:
+- Component types
+- Properties
+- Usage examples
+- Limits
+
+### [Implementation Guide](docs/implementation-guide.md)
+
+Technical guide for implementing in the Rust backend:
+- Data structures
+- Validation
+- Events
+- Tests
+
+## How to Contribute
+
+1. Fork the Stoat repository
+2. Implement changes following the guide
+3. Add tests
+4. Submit a Pull Request
+
+## Status
+
+- [x] Documentation created
+- [x] RFC ready
+- [x] Implementation guide
+- [ ] Backend implementation
+- [ ] Tests
+- [ ] Official documentation
+
+## Contact
+
+- GitHub: https://github.com/stoatchat/stoat
+- Discord: https://stt.gg/Testers

--- a/stoat-components/proposal/RFC_INTERACTIVE_COMPONENTS.md
+++ b/stoat-components/proposal/RFC_INTERACTIVE_COMPONENTS.md
@@ -1,0 +1,288 @@
+# RFC: Interactive Components for Bots
+
+**Status:** Proposal
+**Author:** Stoat Contributors
+**Date:** 2026-08-26
+
+## Summary
+
+This proposal adds support for interactive components (buttons and select menus) for bots on Stoat, similar to Discord and other chat platforms.
+
+## Motivation
+
+Currently, bots on Stoat can only send text messages, embeds, and reactions. This limits user interaction. Interactive components allow:
+
+- Creating forms and polls
+- Confirmation/cancel buttons
+- Selection menus for settings
+- Richer and more intuitive interfaces
+
+## Proposed Components
+
+### 1. Action Row
+
+Container to group components (maximum 5 per row).
+
+```json
+{
+  "type": 1,
+  "components": [...]
+}
+```
+
+### 2. Button
+
+Clickable button with different styles.
+
+```json
+{
+  "type": 2,
+  "style": 1,
+  "label": "Confirm",
+  "custom_id": "confirm_btn",
+  "disabled": false,
+  "emoji": {"name": "check"}
+}
+```
+
+**Styles:**
+| Value | Name | Color |
+|-------|------|-------|
+| 1 | PRIMARY | Blue |
+| 2 | SECONDARY | Gray |
+| 3 | SUCCESS | Green |
+| 4 | DANGER | Red |
+| 5 | LINK | No color (opens URL) |
+
+### 3. Select Menu
+
+Dropdown menu for option selection.
+
+```json
+{
+  "type": 3,
+  "custom_id": "role_select",
+  "options": [
+    {"label": "Option 1", "value": "opt1", "description": "Description"},
+    {"label": "Option 2", "value": "opt2"}
+  ],
+  "placeholder": "Select...",
+  "min_values": 1,
+  "max_values": 1,
+  "disabled": false
+}
+```
+
+## API Schema
+
+### DataMessageSend (updated)
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "content": {"type": "string"},
+    "attachments": {"type": "array"},
+    "embeds": {"type": "array"},
+    "components": {
+      "type": "array",
+      "items": {"$ref": "#/components/schemas/ActionRow"},
+      "nullable": true
+    }
+  }
+}
+```
+
+### ActionRow
+
+```json
+{
+  "type": "object",
+  "required": ["type", "components"],
+  "properties": {
+    "type": {"type": "integer", "enum": [1]},
+    "components": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"$ref": "#/components/schemas/Button"},
+          {"$ref": "#/components/schemas/SelectMenu"}
+        ]
+      },
+      "maxItems": 5
+    }
+  }
+}
+```
+
+### Button
+
+```json
+{
+  "type": "object",
+  "required": ["type", "style", "label"],
+  "properties": {
+    "type": {"type": "integer", "enum": [2]},
+    "style": {"type": "integer", "enum": [1, 2, 3, 4, 5]},
+    "label": {"type": "string", "maxLength": 80},
+    "custom_id": {"type": "string", "maxLength": 100},
+    "disabled": {"type": "boolean"},
+    "emoji": {"$ref": "#/components/schemas/PartialEmoji"},
+    "url": {"type": "string", "format": "uri"}
+  }
+}
+```
+
+### SelectMenu
+
+```json
+{
+  "type": "object",
+  "required": ["type", "custom_id", "options"],
+  "properties": {
+    "type": {"type": "integer", "enum": [3]},
+    "custom_id": {"type": "string", "maxLength": 100},
+    "options": {
+      "type": "array",
+      "items": {"$ref": "#/components/schemas/SelectOption"},
+      "minItems": 1,
+      "maxItems": 25
+    },
+    "placeholder": {"type": "string", "maxLength": 150},
+    "min_values": {"type": "integer", "minimum": 0, "maximum": 25},
+    "max_values": {"type": "integer", "minimum": 1, "maximum": 25},
+    "disabled": {"type": "boolean"}
+  }
+}
+```
+
+### SelectOption
+
+```json
+{
+  "type": "object",
+  "required": ["label", "value"],
+  "properties": {
+    "label": {"type": "string", "maxLength": 100},
+    "value": {"type": "string", "maxLength": 100},
+    "description": {"type": "string", "maxLength": 100},
+    "emoji": {"$ref": "#/components/schemas/PartialEmoji"},
+    "default": {"type": "boolean"}
+  }
+}
+```
+
+## Events
+
+### interaction_create
+
+When a user interacts with a component.
+
+```json
+{
+  "type": "interaction_create",
+  "id": "interaction_id",
+  "token": "interaction_token",
+  "type": 3,
+  "message_id": "message_id",
+  "channel_id": "channel_id",
+  "guild_id": "guild_id",
+  "author": {"$ref": "#/components/schemas/User"},
+  "data": {
+    "custom_id": "confirm_btn",
+    "component_type": 2
+  }
+}
+```
+
+## Responses
+
+### Responding to Interactions
+
+```json
+{
+  "type": 4,
+  "data": {
+    "content": "Action confirmed!",
+    "flags": 64
+  }
+}
+```
+
+```json
+{
+  "type": 7,
+  "data": {
+    "content": "Message edited",
+    "components": []
+  }
+}
+```
+
+```json
+{
+  "type": 7,
+  "data": {
+    "content": "Action processed",
+    "components": []
+  }
+}
+```
+
+## Usage Examples
+
+### Confirmation Buttons
+
+```json
+{
+  "content": "Do you want to delete this message?",
+  "components": [
+    {
+      "type": 1,
+      "components": [
+        {"type": 2, "style": 3, "label": "Yes", "custom_id": "delete_yes"},
+        {"type": 2, "style": 4, "label": "No", "custom_id": "delete_no"}
+      ]
+    }
+  ]
+}
+```
+
+### Selection Menu
+
+```json
+{
+  "content": "Select your role:",
+  "components": [
+    {
+      "type": 1,
+      "components": [
+        {
+          "type": 3,
+          "custom_id": "role_select",
+          "options": [
+            {"label": "Admin", "value": "admin", "description": "Full access"},
+            {"label": "Mod", "value": "mod", "description": "Moderation"},
+            {"label": "Member", "value": "member"}
+          ],
+          "placeholder": "Choose a role..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Limits
+
+- Maximum **5** Action Rows per message
+- Maximum **5** components per Action Row
+- Maximum **25** options per Select Menu
+- **100** characters for custom_id
+- **80** characters for button label
+- **100** characters for option label
+
+## References
+
+- [Discord Interactions](https://discord.com/developers/docs/interactions/receiving-and-responding)
+- [Stoat API Current](https://developers.stoat.chat/api-reference)

--- a/stoat-components/proposal/docs/implementation-guide.md
+++ b/stoat-components/proposal/docs/implementation-guide.md
@@ -1,0 +1,270 @@
+# Implementation Guide - Backend (Rust)
+
+This guide describes how to implement interactive components in the Stoat backend.
+
+## Data Structures
+
+### Add to `revolt-models`
+
+```rust
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ComponentType {
+    ActionRow = 1,
+    Button = 2,
+    SelectMenu = 3,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ButtonStyle {
+    Primary = 1,
+    Secondary = 2,
+    Success = 3,
+    Danger = 4,
+    Link = 5,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Component {
+    #[serde(rename = 1)]
+    ActionRow(ActionRow),
+    #[serde(rename = 2)]
+    Button(Button),
+    #[serde(rename = 3)]
+    SelectMenu(SelectMenu),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct ActionRow {
+    #[validate(length(max = 5))]
+    pub components: Vec<Component>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct Button {
+    pub style: ButtonStyle,
+    #[validate(length(max = 80))]
+    pub label: String,
+    #[validate(length(max = 100))]
+    pub custom_id: Option<String>,
+    #[validate(length(max = 255))]
+    pub url: Option<String>,
+    pub disabled: Option<bool>,
+    pub emoji: Option<PartialEmoji>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct SelectMenu {
+    #[validate(length(max = 100))]
+    pub custom_id: String,
+    #[validate(length(min = 1, max = 25))]
+    pub options: Vec<SelectOption>,
+    #[validate(length(max = 150))]
+    pub placeholder: Option<String>,
+    pub min_values: Option<u32>,
+    pub max_values: Option<u32>,
+    pub disabled: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct SelectOption {
+    #[validate(length(max = 100))]
+    pub label: String,
+    #[validate(length(max = 100))]
+    pub value: String,
+    #[validate(length(max = 100))]
+    pub description: Option<String>,
+    pub emoji: Option<PartialEmoji>,
+    pub default: Option<bool>,
+}
+```
+
+### Update DataMessageSend
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct DataMessageSend {
+    #[validate(length(min = 0, max = 5))]
+    pub components: Option<Vec<Component>>,
+}
+```
+
+## Validation
+
+### Add validation
+
+```rust
+pub fn validate_components(components: &[Component]) -> Result<(), Error> {
+    if components.len() > 5 {
+        return Err(Error::InvalidComponents {
+            message: "Maximum 5 action rows".into(),
+        });
+    }
+    
+    for component in components {
+        match component {
+            Component::ActionRow(row) => {
+                if row.components.len() > 5 {
+                    return Err(Error::InvalidComponents {
+                        message: "Maximum 5 components per row".into(),
+                    });
+                }
+                
+                for inner in &row.components {
+                    if matches!(inner, Component::ActionRow(_)) {
+                        return Err(Error::InvalidComponents {
+                            message: "Cannot nest action rows".into(),
+                        });
+                    }
+                }
+            }
+            Component::Button(btn) => {
+                if btn.style == ButtonStyle::Link && btn.url.is_none() {
+                    return Err(Error::InvalidComponents {
+                        message: "Link buttons must have URL".into(),
+                    });
+                }
+                if btn.style != ButtonStyle::Link && btn.custom_id.is_none() {
+                    return Err(Error::InvalidComponents {
+                        message: "Non-link buttons must have custom_id".into(),
+                    });
+                }
+            }
+            Component::SelectMenu(menu) => {
+                if menu.options.is_empty() {
+                    return Err(Error::InvalidComponents {
+                        message: "Select menu must have options".into(),
+                    });
+                }
+            }
+        }
+    }
+    
+    Ok(())
+}
+```
+
+## Events
+
+### Create interaction event
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Event {
+    InteractionCreate(InteractionCreate),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InteractionCreate {
+    pub id: String,
+    pub token: String,
+    pub interaction_type: InteractionType,
+    pub message_id: Option<String>,
+    pub channel_id: String,
+    pub guild_id: Option<String>,
+    pub member: Option<Member>,
+    pub author: User,
+    pub data: InteractionData,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum InteractionType {
+    #[serde(rename = 2)]
+    MessageComponent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "component_type")]
+pub enum InteractionData {
+    #[serde(rename = 2)]
+    Button { custom_id: String },
+    #[serde(rename = 3)]
+    SelectMenu { custom_id: String, values: Vec<String> },
+}
+```
+
+## Responses
+
+### Response endpoint
+
+```rust
+pub fn routes() -> Router {
+    Router::new()
+        .route("/:id/callback", post(interaction_callback))
+}
+
+async fn interaction_callback(
+    Path(id): Path<String>,
+    Json(data): Json<InteractionResponse>,
+) -> Result<impl IntoResponse, Error> {
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InteractionResponse {
+    pub r#type: ResponseType,
+    pub data: Option<ResponseData>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ResponseType {
+    #[serde(rename = 4)]
+    ChannelMessageWithSource = 4,
+    #[serde(rename = 7)]
+    UpdateMessage = 7,
+}
+```
+
+## Tests
+
+### Unit tests
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_button_serialization() {
+        let button = Button {
+            style: ButtonStyle::Primary,
+            label: "Click me".into(),
+            custom_id: Some("btn_1".into()),
+            url: None,
+            disabled: None,
+            emoji: None,
+        };
+        
+        let json = serde_json::to_string(&button).unwrap();
+        assert!(json.contains("\"type\":2"));
+        assert!(json.contains("\"style\":1"));
+    }
+
+    #[test]
+    fn test_validation() {
+        let row = ActionRow {
+            components: vec![
+                Component::Button(Button {
+                    style: ButtonStyle::Link,
+                    label: "Link".into(),
+                    custom_id: None,
+                    url: None,
+                    disabled: None,
+                    emoji: None,
+                })
+            ],
+        };
+        
+        assert!(validate_components(&[Component::ActionRow(row)]).is_err());
+    }
+}
+```
+
+## References
+
+- [Revolt Models](https://github.com/stoatchat/stoat/tree/main/crates/models)
+- [Revolt Delta](https://github.com/stoatchat/stoat/tree/main/crates/delta)
+- [API OpenAPI Spec](https://stoat.chat/api/openapi.json)

--- a/stoat-components/proposal/docs/interactive-components.md
+++ b/stoat-components/proposal/docs/interactive-components.md
@@ -1,0 +1,199 @@
+---
+title: Interactive Components
+description: Buttons and select menus for Stoat bots
+sidebar_position: 1
+---
+
+# Interactive Components
+
+Interactive components allow you to create rich interfaces in your bots, such as buttons, select menus, and forms.
+
+:::caution
+This feature is currently in development. Full support will be added soon.
+:::
+
+## Component Types
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| Action Row | 1 | Container to group components |
+| Button | 2 | Clickable button |
+| Select Menu | 3 | Dropdown menu |
+
+## Action Row
+
+Action Row is a container that groups components. Each message can have up to **5 Action Rows**.
+
+```json
+{
+  "type": 1,
+  "components": [...]
+}
+```
+
+## Button
+
+Buttons allow users to interact with messages.
+
+### Styles
+
+| Style | Value | Color | Use |
+|-------|-------|-------|-----|
+| PRIMARY | 1 | Blue | Main action |
+| SECONDARY | 2 | Gray | Secondary action |
+| SUCCESS | 3 | Green | Confirmation |
+| DANGER | 4 | Red | Delete/Cancel |
+| LINK | 5 | No color | Open URL |
+
+### Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| type | integer | Yes | Always 2 |
+| style | integer | Yes | Button style |
+| label | string | Yes | Button text (max 80) |
+| custom_id | string | Yes* | Unique ID (max 100) |
+| disabled | boolean | No | Disabled state |
+| emoji | object | No | Emoji next to label |
+| url | string | Yes* | URL (LINK only) |
+
+*\* custom_id is required except for LINK. url is required only for LINK.*
+
+### Examples
+
+#### Primary Button
+
+```json
+{
+  "type": 2,
+  "style": 1,
+  "label": "Click Here",
+  "custom_id": "primary_btn"
+}
+```
+
+#### Button with Emoji
+
+```json
+{
+  "type": 2,
+  "style": 3,
+  "label": "Like",
+  "custom_id": "like_btn",
+  "emoji": {"name": "heart"}
+}
+```
+
+#### Link Button
+
+```json
+{
+  "type": 2,
+  "style": 5,
+  "label": "Visit Site",
+  "url": "https://stoat.chat"
+}
+```
+
+#### Disabled Button
+
+```json
+{
+  "type": 2,
+  "style": 2,
+  "label": "Unavailable",
+  "custom_id": "disabled_btn",
+  "disabled": true
+}
+```
+
+## Select Menu
+
+Select menus allow choosing one or more options from a list.
+
+### Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| type | integer | Yes | Always 3 |
+| custom_id | string | Yes | Unique ID (max 100) |
+| options | array | Yes | Options list (1-25) |
+| placeholder | string | No | Placeholder text (max 150) |
+| min_values | integer | No | Minimum selections (default: 1) |
+| max_values | integer | No | Maximum selections (default: 1) |
+| disabled | boolean | No | Disabled state |
+
+### Options
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| label | string | Yes | Option text (max 100) |
+| value | string | Yes | Returned value (max 100) |
+| description | string | No | Description (max 100) |
+| emoji | object | No | Option emoji |
+| default | boolean | No | Pre-selected |
+
+### Example
+
+```json
+{
+  "type": 3,
+  "custom_id": "color_select",
+  "options": [
+    {"label": "Red", "value": "red", "emoji": {"name": "red_circle"}},
+    {"label": "Green", "value": "green", "emoji": {"name": "green_circle"}},
+    {"label": "Blue", "value": "blue", "emoji": {"name": "blue_circle"}}
+  ],
+  "placeholder": "Choose a color...",
+  "min_values": 1,
+  "max_values": 1
+}
+```
+
+## Messages with Components
+
+### Complete Example
+
+```json
+{
+  "content": "Select an action:",
+  "components": [
+    {
+      "type": 1,
+      "components": [
+        {
+          "type": 3,
+          "custom_id": "action_select",
+          "options": [
+            {"label": "Ban", "value": "ban"},
+            {"label": "Mute", "value": "mute"},
+            {"label": "Kick", "value": "kick"}
+          ],
+          "placeholder": "Action..."
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "components": [
+        {"type": 2, "style": 3, "label": "Confirm", "custom_id": "confirm"},
+        {"type": 2, "style": 4, "label": "Cancel", "custom_id": "cancel"}
+      ]
+    }
+  ]
+}
+```
+
+## Limits
+
+- **5** Action Rows per message
+- **5** components per Action Row
+- **25** options per Select Menu
+- **100** characters for custom_id
+- **80** characters for button label
+- **100** characters for option label
+
+## Next Steps
+
+- [Interaction Events](/developers/events/interactions)
+- [Interaction Responses](/developers/api/interaction-responses)

--- a/stoat-components/pyproject.toml
+++ b/stoat-components/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.backends._legacy:_Backend"
+
+[project]
+name = "stoat-components"
+version = "0.1.0"
+description = "Interactive UI components for Stoat bots"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.8"
+authors = [
+    {name = "Stoat Contributors"}
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.urls]
+Homepage = "https://github.com/stoat/components"
+Issues = "https://github.com/stoat/components/issues"

--- a/stoat-components/send_components.py
+++ b/stoat-components/send_components.py
@@ -1,0 +1,204 @@
+"""
+Script to test components visually on Stoat.
+
+Before running:
+1. Create a bot at https://stoat.chat/developers
+2. Set environment variables STOAT_TOKEN and STOAT_CHANNEL_ID
+3. Run: python send_components.py
+
+Example (Windows PowerShell):
+  $env:STOAT_TOKEN="your_token_here"
+  $env:STOAT_CHANNEL_ID="your_channel_id_here"
+  python send_components.py
+
+Example (Linux/Mac):
+  export STOAT_TOKEN="your_token_here"
+  export STOAT_CHANNEL_ID="your_channel_id_here"
+  python send_components.py
+"""
+
+import os
+import requests
+import json
+
+
+TOKEN = os.environ.get("STOAT_TOKEN")
+CHANNEL_ID = os.environ.get("STOAT_CHANNEL_ID")
+
+API_URL = "https://api.stoat.chat"
+
+
+def send_message(channel_id: str, content: str, components: list = None):
+    headers = {
+        "X-Bot-Token": TOKEN,
+        "Content-Type": "application/json",
+    }
+
+    payload = {"content": content}
+    if components:
+        payload["components"] = components
+
+    response = requests.post(
+        f"{API_URL}/channels/{channel_id}/messages",
+        headers=headers,
+        json=payload,
+    )
+
+    if response.status_code in (200, 201):
+        print(f"  Message sent successfully!")
+        return response.json()
+    else:
+        print(f"  Error {response.status_code}: {response.text}")
+        return None
+
+
+def test_buttons():
+    print("\n1. Testing buttons...")
+
+    components = [
+        {
+            "type": 1,
+            "components": [
+                {"type": 2, "style": 1, "label": "Primary", "custom_id": "btn_primary"},
+                {"type": 2, "style": 2, "label": "Secondary", "custom_id": "btn_secondary"},
+                {"type": 2, "style": 3, "label": "Success", "custom_id": "btn_success"},
+                {"type": 2, "style": 4, "label": "Danger", "custom_id": "btn_danger"},
+            ],
+        }
+    ]
+
+    send_message(CHANNEL_ID, "Button test:", components)
+
+
+def test_link_button():
+    print("\n2. Testing link button...")
+
+    components = [
+        {
+            "type": 1,
+            "components": [
+                {"type": 2, "style": 5, "label": "Visit Stoat", "url": "https://stoat.chat"},
+            ],
+        }
+    ]
+
+    send_message(CHANNEL_ID, "Link button:", components)
+
+
+def test_disabled_button():
+    print("\n3. Testing disabled button...")
+
+    components = [
+        {
+            "type": 1,
+            "components": [
+                {"type": 2, "style": 1, "label": "Active", "custom_id": "active_btn"},
+                {"type": 2, "style": 1, "label": "Disabled", "custom_id": "disabled_btn", "disabled": True},
+            ],
+        }
+    ]
+
+    send_message(CHANNEL_ID, "Active vs disabled buttons:", components)
+
+
+def test_select_menu():
+    print("\n4. Testing select menu...")
+
+    components = [
+        {
+            "type": 1,
+            "components": [
+                {
+                    "type": 3,
+                    "custom_id": "role_selector",
+                    "options": [
+                        {"label": "Admin", "value": "admin", "description": "Full access"},
+                        {"label": "Moderator", "value": "mod", "description": "Chat moderation"},
+                        {"label": "Member", "value": "member", "description": "Default member"},
+                    ],
+                    "placeholder": "Select a role...",
+                }
+            ],
+        }
+    ]
+
+    send_message(CHANNEL_ID, "Select menu (dropdown):", components)
+
+
+def test_multi_select():
+    print("\n5. Testing multi-select...")
+
+    components = [
+        {
+            "type": 1,
+            "components": [
+                {
+                    "type": 3,
+                    "custom_id": "channel_selector",
+                    "options": [
+                        {"label": "General", "value": "general"},
+                        {"label": "Help", "value": "help"},
+                        {"label": "Off-Topic", "value": "offtopic"},
+                    ],
+                    "placeholder": "Select channels...",
+                    "min_values": 1,
+                    "max_values": 3,
+                }
+            ],
+        }
+    ]
+
+    send_message(CHANNEL_ID, "Multi-select (choose multiple):", components)
+
+
+def test_mixed_components():
+    print("\n6. Testing mixed components...")
+
+    components = [
+        {
+            "type": 1,
+            "components": [
+                {
+                    "type": 3,
+                    "custom_id": "action_select",
+                    "options": [
+                        {"label": "Ban", "value": "ban"},
+                        {"label": "Mute", "value": "mute"},
+                        {"label": "Kick", "value": "kick"},
+                    ],
+                    "placeholder": "Select an action...",
+                }
+            ],
+        },
+        {
+            "type": 1,
+            "components": [
+                {"type": 2, "style": 3, "label": "Confirm", "custom_id": "confirm_action"},
+                {"type": 2, "style": 4, "label": "Cancel", "custom_id": "cancel_action"},
+            ],
+        },
+    ]
+
+    send_message(CHANNEL_ID, "Select menu + buttons:", components)
+
+
+if __name__ == "__main__":
+    if not TOKEN or not CHANNEL_ID:
+        print("ERROR: Set STOAT_TOKEN and STOAT_CHANNEL_ID environment variables!")
+        print("")
+        print("Windows PowerShell:")
+        print('  $env:STOAT_TOKEN="your_token"')
+        print('  $env:STOAT_CHANNEL_ID="your_channel_id"')
+        print("")
+        print("Linux/Mac:")
+        print('  export STOAT_TOKEN="your_token"')
+        print('  export STOAT_CHANNEL_ID="your_channel_id"')
+    else:
+        print("Sending components to Stoat...")
+        test_buttons()
+        test_link_button()
+        test_disabled_button()
+        test_select_menu()
+        test_multi_select()
+        test_mixed_components()
+        print("\nDone! Check the channel on Stoat.")

--- a/stoat-components/stoat_components/__init__.py
+++ b/stoat-components/stoat_components/__init__.py
@@ -1,0 +1,13 @@
+from .component import Component
+from .button import Button, ButtonStyle
+from .select_menu import SelectMenu, SelectOption
+
+__all__ = [
+    "Component",
+    "Button",
+    "ButtonStyle",
+    "SelectMenu",
+    "SelectOption",
+]
+
+__version__ = "0.1.0"

--- a/stoat-components/stoat_components/button.py
+++ b/stoat-components/stoat_components/button.py
@@ -1,0 +1,64 @@
+from enum import IntEnum
+from typing import Any, Dict, Optional, Callable
+
+
+class ButtonStyle(IntEnum):
+    """Button style variants."""
+    PRIMARY = 1
+    SECONDARY = 2
+    SUCCESS = 3
+    DANGER = 4
+    LINK = 5
+
+
+class Button:
+    """Interactive button component for Stoat bots."""
+
+    def __init__(
+        self,
+        label: str,
+        style: ButtonStyle = ButtonStyle.PRIMARY,
+        custom_id: Optional[str] = None,
+        disabled: bool = False,
+        emoji: Optional[str] = None,
+        url: Optional[str] = None,
+    ):
+        if style == ButtonStyle.LINK and not url:
+            raise ValueError("Link buttons must have a URL")
+        if style != ButtonStyle.LINK and not custom_id:
+            raise ValueError("Non-link buttons must have a custom_id")
+
+        self.label = label
+        self.style = style
+        self._custom_id = custom_id
+        self.disabled = disabled
+        self.emoji = emoji
+        self.url = url
+        self._callback: Optional[Callable] = None
+
+    @property
+    def custom_id(self) -> Optional[str]:
+        return self._custom_id
+
+    def callback(self, func: Callable):
+        """Decorator to register a callback function."""
+        self._callback = func
+        return func
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {
+            "type": 2,
+            "style": self.style.value,
+            "label": self.label,
+            "disabled": self.disabled,
+        }
+        if self._custom_id:
+            data["custom_id"] = self._custom_id
+        if self.emoji:
+            data["emoji"] = {"name": self.emoji}
+        if self.url:
+            data["url"] = self.url
+        return data
+
+    def __repr__(self) -> str:
+        return f"<Button label='{self.label}' style={self.style.name}>"

--- a/stoat-components/stoat_components/component.py
+++ b/stoat-components/stoat_components/component.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+class Component(ABC):
+    """Base class for all Stoat bot components."""
+
+    def __init__(self, custom_id: Optional[str] = None):
+        self._custom_id = custom_id
+        self._disabled = False
+
+    @property
+    def custom_id(self) -> Optional[str]:
+        return self._custom_id
+
+    @custom_id.setter
+    def custom_id(self, value: str):
+        self._custom_id = value
+
+    @property
+    def disabled(self) -> bool:
+        return self._disabled
+
+    def disable(self):
+        self._disabled = True
+        return self
+
+    def enable(self):
+        self._disabled = False
+        return self
+
+    @abstractmethod
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert component to dictionary format for API."""
+        pass
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} custom_id={self._custom_id}>"

--- a/stoat-components/stoat_components/select_menu.py
+++ b/stoat-components/stoat_components/select_menu.py
@@ -1,0 +1,81 @@
+from typing import Any, Dict, List, Optional
+
+
+class SelectOption:
+    """Option for a select menu."""
+
+    def __init__(
+        self,
+        label: str,
+        value: str,
+        description: Optional[str] = None,
+        emoji: Optional[str] = None,
+        default: bool = False,
+    ):
+        self.label = label
+        self.value = value
+        self.description = description
+        self.emoji = emoji
+        self.default = default
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {
+            "label": self.label,
+            "value": self.value,
+        }
+        if self.description:
+            data["description"] = self.description
+        if self.emoji:
+            data["emoji"] = {"name": self.emoji}
+        if self.default:
+            data["default"] = True
+        return data
+
+    def __repr__(self) -> str:
+        return f"<SelectOption label='{self.label}' value='{self.value}'>"
+
+
+class SelectMenu:
+    """Dropdown select menu component for Stoat bots."""
+
+    def __init__(
+        self,
+        custom_id: str,
+        options: List[SelectOption],
+        placeholder: Optional[str] = None,
+        min_values: int = 1,
+        max_values: int = 1,
+        disabled: bool = False,
+    ):
+        self._custom_id = custom_id
+        self.options = options
+        self.placeholder = placeholder
+        self.min_values = min_values
+        self.max_values = max_values
+        self.disabled = disabled
+        self._callback = None
+
+    @property
+    def custom_id(self) -> Optional[str]:
+        return self._custom_id
+
+    def callback(self, func):
+        """Decorator to register a callback function."""
+        self._callback = func
+        return func
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {
+            "type": 3,
+            "custom_id": self._custom_id,
+            "options": [opt.to_dict() for opt in self.options],
+            "min_values": self.min_values,
+            "max_values": self.max_values,
+            "disabled": self.disabled,
+        }
+        if self.placeholder:
+            data["placeholder"] = self.placeholder
+        return data
+
+    def __repr__(self) -> str:
+        return f"<SelectMenu custom_id='{self._custom_id}' options={len(self.options)}>"

--- a/stoat-components/test_components.py
+++ b/stoat-components/test_components.py
@@ -1,0 +1,117 @@
+"""
+Complete test suite for stoat-components.
+Run: python test_components.py
+"""
+
+import json
+from stoat_components import Button, ButtonStyle, SelectMenu, SelectOption
+
+
+def test_button_styles():
+    print("=== Button Styles Test ===\n")
+
+    styles = [
+        ("Primary", ButtonStyle.PRIMARY),
+        ("Secondary", ButtonStyle.SECONDARY),
+        ("Success", ButtonStyle.SUCCESS),
+        ("Danger", ButtonStyle.DANGER),
+    ]
+
+    for name, style in styles:
+        btn = Button(label=name, style=style, custom_id=f"btn_{style.name.lower()}")
+        print(f"{name}: {json.dumps(btn.to_dict(), indent=2)}")
+
+    link_btn = Button(
+        label="Visit Site",
+        style=ButtonStyle.LINK,
+        url="https://stoat.chat"
+    )
+    print(f"\nLink: {json.dumps(link_btn.to_dict(), indent=2)}")
+
+
+def test_button_features():
+    print("\n=== Button Features Test ===\n")
+
+    btn_emoji = Button(
+        label="Like",
+        style=ButtonStyle.PRIMARY,
+        custom_id="like_btn",
+        emoji="heart"
+    )
+    print(f"With emoji: {json.dumps(btn_emoji.to_dict(), indent=2)}")
+
+    btn_disabled = Button(
+        label="Unavailable",
+        style=ButtonStyle.SECONDARY,
+        custom_id="disabled_btn",
+        disabled=True
+    )
+    print(f"\nDisabled: {json.dumps(btn_disabled.to_dict(), indent=2)}")
+
+    @btn_emoji.callback
+    async def on_like(interaction):
+        print(f"Button clicked by {interaction.user}")
+
+    print(f"\nCallback registered: {btn_emoji._callback is not None}")
+
+
+def test_select_menu():
+    print("\n=== Select Menu Test ===\n")
+
+    options = [
+        SelectOption("Option 1", "opt1", description="First option"),
+        SelectOption("Option 2", "opt2", description="Second option"),
+        SelectOption("Option 3", "opt3", description="Third option"),
+    ]
+
+    menu = SelectMenu(
+        custom_id="simple_menu",
+        options=options,
+        placeholder="Select an option..."
+    )
+    print(f"Simple menu:\n{json.dumps(menu.to_dict(), indent=2)}")
+
+    multi_options = [
+        SelectOption("Channel 1", "ch1"),
+        SelectOption("Channel 2", "ch2"),
+        SelectOption("Channel 3", "ch3"),
+    ]
+
+    multi_menu = SelectMenu(
+        custom_id="multi_menu",
+        options=multi_options,
+        placeholder="Select multiple channels...",
+        min_values=1,
+        max_values=3
+    )
+    print(f"\nMulti-select:\n{json.dumps(multi_menu.to_dict(), indent=2)}")
+
+
+def test_action_row():
+    print("\n=== Action Row Test ===\n")
+
+    confirm = Button("Yes", ButtonStyle.SUCCESS, custom_id="yes")
+    cancel = Button("No", ButtonStyle.DANGER, custom_id="no")
+    link = Button("Help", ButtonStyle.LINK, url="https://stoat.chat/help")
+
+    row = {
+        "type": 1,
+        "components": [
+            confirm.to_dict(),
+            cancel.to_dict(),
+            link.to_dict(),
+        ]
+    }
+
+    print(json.dumps(row, indent=2))
+
+
+if __name__ == "__main__":
+    print("Testing stoat-components v0.1.0\n")
+
+    test_button_styles()
+    test_button_features()
+    test_select_menu()
+    test_action_row()
+
+    print("\nAll tests passed!")


### PR DESCRIPTION
## Summary

This PR adds a complete interactive components library for Stoat bots, including:

### Components
- **Button** - Clickable buttons with 5 styles (Primary, Secondary, Success, Danger, Link)
- **SelectMenu** - Dropdown menus with single/multi-select support
- **ActionRow** - Container for grouping components

### Files Added
- stoat-components/ - Python library for creating components
- proposal/ - Complete RFC and documentation for API integration
- xamples/ - Usage examples
- 	est_components.py - Test suite
- send_components.py - Visual testing script

### RFC Proposal
Includes a complete proposal for adding component support to the Stoat API:
- Updated DataMessageSend schema
- New interaction_create events
- Interaction response endpoint
- Full documentation for developers

### Testing
Run tests with:
`ash
pip install -e stoat-components
python stoat-components/test_components.py
`

Related: https://github.com/Kalebinhoo/stoat-components