### PR TITLE
fix: saturate ratelimits to not cause overflows

### DIFF
--- a/crates/core/ratelimits/src/ratelimiter.rs
+++ b/crates/core/ratelimits/src/ratelimiter.rs
@@ -98,7 +98,7 @@ impl Entry {
         if now.as_millis() > self.reset {
             limit
         } else {
-            (limit + 1).saturating_sub(self.used)
+            (limit.saturating_add(1)).saturating_sub(self.used)
         }
     }
 
@@ -167,7 +167,7 @@ impl Ratelimiter {
 
         entry.is_expired(now);
         entry.save(&mut conn, key).await;
-        ratelimiter.remaining -= 1;
+        ratelimiter.remaining = ratelimiter.remaining.saturating_sub(1);
 
         Ok(ratelimiter)
     }

--- a/crates/services/autumn/src/main.rs
+++ b/crates/services/autumn/src/main.rs
@@ -100,5 +100,5 @@ async fn main() -> Result<(), std::io::Error> {
     // Configure TCP listener and bind
     let address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 14704));
     let listener = TcpListener::bind(&address).await?;
-    axum::serve(listener, app.into_make_service()).await
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await
 }

--- a/crates/services/gifbox/src/main.rs
+++ b/crates/services/gifbox/src/main.rs
@@ -108,5 +108,5 @@ async fn main() -> Result<(), std::io::Error> {
     tracing::info!("Play around with the API: http://localhost:14706/scalar");
     let address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 14706));
     let listener = TcpListener::bind(&address).await?;
-    axum::serve(listener, app.into_make_service()).await
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await
 }

--- a/crates/services/january/src/main.rs
+++ b/crates/services/january/src/main.rs
@@ -65,5 +65,5 @@ async fn main() -> Result<(), std::io::Error> {
     tracing::info!("Play around with the API: http://localhost:14705/scalar");
     let address = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 14705));
     let listener = TcpListener::bind(&address).await?;
-    axum::serve(listener, app.into_make_service()).await
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await
 }


### PR DESCRIPTION
Ratelimits did not use saturating ops, causing ratelimits to overflow/underflow, and triggering ratelimits.

- `main` <!-- branch-stack -->
  - \#957 :point\_left:
