### PR TITLE
fix: don't write quotes to db on last_message_id

### DIFF
--- a/crates/core/database/src/models/admin_migrations/ops/mongodb/scripts.rs
+++ b/crates/core/database/src/models/admin_migrations/ops/mongodb/scripts.rs
@@ -26,7 +26,7 @@ struct MigrationInfo {
     revision: i32,
 }
 
-pub const LATEST_REVISION: i32 = 53; // MUST BE +1 to last migration
+pub const LATEST_REVISION: i32 = 54; // MUST BE +1 to last migration
 
 pub async fn migrate_database(db: &MongoDb) {
     let migrations = db.col::<Document>("migrations");
@@ -1559,6 +1559,22 @@ pub async fn run_migrations(db: &MongoDb, revision: i32) -> i32 {
         } else {
             info!("Skipping migration [revision 52 / 20-08-2026]: Discover endpoints");
         }
+    }
+
+    if revision <= 53 {
+        info!(
+            "Running migration [revision 53 / 30-08-2026]: [FIX] clean bad last_channel_id values"
+        );
+        db.db()
+            .collection::<Document>("channels")
+            .update_many(
+                doc! {"last_message_id": {"$regex": "\""}},
+                vec![
+                    doc! {"$set": {"last_message_id": {"$trim": {"input": "$last_message_id", "chars": "\""}}}},
+                ],
+            )
+            .await
+            .expect("Failed to clean up channels");
     }
 
     // Reminder to update LATEST_REVISION when adding new migrations.

--- a/crates/core/database/src/models/channels/ops/mongodb.rs
+++ b/crates/core/database/src/models/channels/ops/mongodb.rs
@@ -318,7 +318,7 @@ impl AbstractChannels for MongoDb {
             .sort(doc! {"_id": -1})
             .projection(doc! {"_id": 1})
             .await
-            .map(|doc| doc.map(|d| d.get("_id").expect("Missing _id").to_string()))
+            .map(|doc| doc.map(|d| String::from(d.get_str("_id").expect("failed to get _id"))))
             .map_err(|_| create_database_error!("find_one", "messages"))
     }
 


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes an issue where quotes were being written to the database on channels.last\_message\_id.

## How was this PR tested?

Ran the db and verified the issue no longer occurs.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

N/A

- `main` <!-- branch-stack -->
  - \#968 :point\_left:
