### PR TITLE
feat: e2eeeeeeeeee

### DIFF
--- a/crates/core/database/src/models/channels/model.rs
+++ b/crates/core/database/src/models/channels/model.rs
@@ -72,6 +72,10 @@ auto_derived!(
             /// Whether this group is marked as not safe for work
             #[serde(skip_serializing_if = "crate::if_false", default)]
             nsfw: bool,
+
+            /// Whether this group is end-to-end encrypted
+            #[serde(skip_serializing_if = "crate::if_false", default)]
+            e2e: bool,
         },
         /// Text channel belonging to a server
         TextChannel {
@@ -115,6 +119,10 @@ auto_derived!(
             /// The channel's slowmode delay in seconds
             #[serde(skip_serializing_if = "Option::is_none")]
             slowmode: Option<u64>,
+
+            /// Whether this channel is end-to-end encrypted
+            #[serde(skip_serializing_if = "crate::if_false", default)]
+            e2e: bool,
         },
     }
 
@@ -153,6 +161,8 @@ auto_derived!(
         pub voice: Option<VoiceInformation>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub slowmode: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub e2e: Option<bool>,
     }
 
     /// Optional fields on channel object
@@ -215,6 +225,7 @@ impl Channel {
                 nsfw: data.nsfw.unwrap_or(false),
                 voice: data.voice.map(|voice| voice.into()),
                 slowmode: None,
+                e2e: data.e2e.unwrap_or(false),
             },
             v0::LegacyServerChannelType::Voice => Channel::TextChannel {
                 id: id.clone(),
@@ -228,6 +239,7 @@ impl Channel {
                 nsfw: data.nsfw.unwrap_or(false),
                 voice: Some(data.voice.unwrap_or_default().into()),
                 slowmode: None,
+                e2e: data.e2e.unwrap_or(false),
             },
         };
 
@@ -291,6 +303,7 @@ impl Channel {
             permissions: None,
 
             nsfw: data.nsfw.unwrap_or(false),
+            e2e: data.e2e.unwrap_or(false),
         };
 
         db.insert_channel(&channel).await?;
@@ -560,7 +573,7 @@ impl Channel {
                     slowmode.take();
                 }
                 _ => {}
-            }
+            },
         }
     }
 

--- a/crates/core/database/src/models/file_hashes/model.rs
+++ b/crates/core/database/src/models/file_hashes/model.rs
@@ -63,6 +63,7 @@ impl FileHash {
         tag: String,
         filename: String,
         uploader_id: String,
+        e2e_id: Option<String>,
     ) -> File {
         File {
             id,
@@ -88,6 +89,7 @@ impl FileHash {
             object_id: None,
             server_id: None,
             user_id: None,
+            e2e_id,
         }
     }
 }

--- a/crates/core/database/src/models/files/model.rs
+++ b/crates/core/database/src/models/files/model.rs
@@ -54,6 +54,10 @@ auto_derived_partial!(
         /// Id of the object this file is associated with
         #[serde(skip_serializing_if = "Option::is_none")]
         pub object_id: Option<String>,
+
+        /// Key's channel id, if encrypted
+       #[serde(skip_serializing_if = "Option::is_none")]
+     pub   e2e_id: Option<String>,
     },
     "PartialFile"
 );

--- a/crates/core/database/src/util/bridge/v0.rs
+++ b/crates/core/database/src/util/bridge/v0.rs
@@ -209,6 +209,7 @@ impl From<crate::Channel> for Channel {
                 last_message_id,
                 permissions,
                 nsfw,
+                e2e,
             } => Channel::Group {
                 id,
                 name,
@@ -219,6 +220,7 @@ impl From<crate::Channel> for Channel {
                 last_message_id,
                 permissions,
                 nsfw,
+                e2e,
             },
             crate::Channel::TextChannel {
                 id,
@@ -232,6 +234,7 @@ impl From<crate::Channel> for Channel {
                 nsfw,
                 voice,
                 slowmode,
+                e2e,
             } => Channel::TextChannel {
                 id,
                 server,
@@ -244,6 +247,7 @@ impl From<crate::Channel> for Channel {
                 nsfw,
                 voice: voice.map(|voice| voice.into()),
                 slowmode,
+                e2e,
             },
         }
     }
@@ -275,6 +279,7 @@ impl From<Channel> for crate::Channel {
                 last_message_id,
                 permissions,
                 nsfw,
+                e2e,
             } => crate::Channel::Group {
                 id,
                 name,
@@ -285,6 +290,7 @@ impl From<Channel> for crate::Channel {
                 last_message_id,
                 permissions,
                 nsfw,
+                e2e,
             },
             Channel::TextChannel {
                 id,
@@ -298,6 +304,7 @@ impl From<Channel> for crate::Channel {
                 nsfw,
                 voice,
                 slowmode,
+                e2e,
             } => crate::Channel::TextChannel {
                 id,
                 server,
@@ -310,6 +317,7 @@ impl From<Channel> for crate::Channel {
                 nsfw,
                 voice: voice.map(|voice| voice.into()),
                 slowmode,
+                e2e,
             },
         }
     }
@@ -330,6 +338,7 @@ impl From<crate::PartialChannel> for PartialChannel {
             last_message_id: value.last_message_id,
             voice: value.voice.map(|voice| voice.into()),
             slowmode: value.slowmode,
+            e2e: value.e2e,
         }
     }
 }
@@ -349,6 +358,7 @@ impl From<PartialChannel> for crate::PartialChannel {
             last_message_id: value.last_message_id,
             voice: value.voice.map(|voice| voice.into()),
             slowmode: value.slowmode,
+            e2e: value.e2e,
         }
     }
 }
@@ -423,6 +433,7 @@ impl From<crate::File> for File {
             user_id: value.user_id,
             server_id: value.server_id,
             object_id: value.object_id,
+            e2e_id: value.e2e_id,
         }
     }
 }
@@ -446,6 +457,7 @@ impl From<File> for crate::File {
             uploaded_at: None,
             uploader_id: None,
             used_for: None,
+            e2e_id: value.e2e_id,
         }
     }
 }

--- a/crates/core/models/src/v0/channels.rs
+++ b/crates/core/models/src/v0/channels.rs
@@ -67,6 +67,13 @@ auto_derived!(
                 serde(skip_serializing_if = "crate::if_false", default)
             )]
             nsfw: bool,
+
+            /// Whether this group is end-to-end encrypted
+            #[cfg_attr(
+                feature = "serde",
+                serde(skip_serializing_if = "crate::if_false", default)
+            )]
+            e2e: bool,
         },
         /// Text channel belonging to a server
         TextChannel {
@@ -116,6 +123,13 @@ auto_derived!(
             /// The channel's slowmode delay in seconds
             #[serde(skip_serializing_if = "Option::is_none")]
             slowmode: Option<u64>,
+
+            /// Whether this channel is end-to-end encrypted
+            #[cfg_attr(
+                feature = "serde",
+                serde(skip_serializing_if = "crate::if_false", default)
+            )]
+            e2e: bool,
         },
     }
 
@@ -156,6 +170,8 @@ auto_derived!(
         pub voice: Option<VoiceInformation>,
         #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
         pub slowmode: Option<u64>,
+        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+        pub e2e: Option<bool>,
     }
 
     /// Optional fields on channel object
@@ -203,6 +219,10 @@ auto_derived!(
         /// Fields to remove from channel
         #[cfg_attr(feature = "serde", serde(default))]
         pub remove: Vec<FieldsChannel>,
+
+        /// Whether this channel is end-to-end encrypted
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub e2e: Option<bool>,
     }
 
     /// Create new group
@@ -227,6 +247,9 @@ auto_derived!(
         /// Whether this group is age-restricted
         #[serde(skip_serializing_if = "Option::is_none")]
         pub nsfw: Option<bool>,
+        /// Whether this group is end-to-end encrypted
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub e2e: Option<bool>,
     }
 
     /// Server Channel Type
@@ -255,10 +278,12 @@ auto_derived!(
         /// Whether this channel is age restricted
         #[serde(skip_serializing_if = "Option::is_none")]
         pub nsfw: Option<bool>,
-
         /// Voice Information for when this channel is also a voice channel
         #[serde(skip_serializing_if = "Option::is_none")]
         pub voice: Option<VoiceInformation>,
+        /// Whether this channel is end-to-end encrypted
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub e2e: Option<bool>,
     }
 
     /// New default permissions

--- a/crates/core/models/src/v0/files.rs
+++ b/crates/core/models/src/v0/files.rs
@@ -35,6 +35,10 @@ auto_derived!(
         /// Id of the object this file is associated with
         #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
         pub object_id: Option<String>,
+
+/// Key's channel id, if encrypted
+#[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+     pub   e2e_id: Option<String>,
     }
 
     /// Metadata associated with a file

--- a/crates/delta/src/routes/channels/channel_edit.rs
+++ b/crates/delta/src/routes/channels/channel_edit.rs
@@ -47,6 +47,7 @@ pub async fn edit(
         && data.voice.is_none()
         && data.slowmode.is_none()
         && data.remove.is_empty()
+        && data.e2e.is_none()
     {
         return Ok(Json(channel.into()));
     }
@@ -104,6 +105,7 @@ pub async fn edit(
             description,
             icon,
             nsfw,
+            e2e,
             ..
         } => {
             if data.remove.contains(&v0::FieldsChannel::Icon) {
@@ -142,6 +144,11 @@ pub async fn edit(
             if let Some(new_nsfw) = data.nsfw {
                 *nsfw = new_nsfw;
                 partial.nsfw = Some(new_nsfw);
+            }
+
+            if let Some(new_e2e) = data.e2e {
+                *e2e = new_e2e;
+                partial.e2e = Some(new_e2e);
             }
 
             // Send out mutation system messages.
@@ -208,6 +215,7 @@ pub async fn edit(
             nsfw,
             voice,
             slowmode,
+            e2e,
             ..
         } => {
             if data.remove.contains(&v0::FieldsChannel::Icon) {
@@ -254,6 +262,11 @@ pub async fn edit(
                 partial.nsfw = Some(new_nsfw);
             }
 
+            if let Some(new_e2e) = data.e2e {
+                *e2e = new_e2e;
+                partial.e2e = Some(new_e2e);
+            }
+
             if let Some(new_voice) = data.voice {
                 *voice = Some(new_voice.clone().into());
                 partial.voice = Some(new_voice.into());
@@ -291,7 +304,13 @@ pub async fn edit(
             before,
             after: partial,
         }
-        .insert(db, channel.server().unwrap().to_string(), reason, user.id, None)
+        .insert(
+            db,
+            channel.server().unwrap().to_string(),
+            reason,
+            user.id,
+            None,
+        )
         .await;
     };
 

--- a/crates/delta/src/routes/channels/message_send.rs
+++ b/crates/delta/src/routes/channels/message_send.rs
@@ -233,6 +233,7 @@ mod test {
                 description: None,
                 nsfw: Some(false),
                 voice: None,
+                e2e: Some(false),
             },
             true,
         )
@@ -268,6 +269,7 @@ mod test {
             last_message_id: None,
             voice: None,
             slowmode: None,
+            e2e: None,
         };
         locked_channel
             .update(&harness.db, partial, vec![])

--- a/crates/delta/src/routes/invites/invite_fetch.rs
+++ b/crates/delta/src/routes/invites/invite_fetch.rs
@@ -8,7 +8,10 @@ use rocket::{serde::json::Json, State};
 /// Fetch an invite by its id.
 #[openapi(tag = "Invites")]
 #[get("/<target>")]
-pub async fn fetch(db: &State<Database>, target: Reference<'_>) -> Result<Json<v0::InviteResponse>> {
+pub async fn fetch(
+    db: &State<Database>,
+    target: Reference<'_>,
+) -> Result<Json<v0::InviteResponse>> {
     Ok(Json(match target.as_invite(db).await? {
         Invite::Server {
             channel, creator, ..
@@ -195,7 +198,8 @@ mod test {
                 name: "Voice Channel".to_string(),
                 description: None,
                 nsfw: Some(false),
-                voice: None
+                voice: None,
+                e2e: Some(false),
             },
             true,
         )

--- a/crates/delta/src/routes/servers/audit_log_query.rs
+++ b/crates/delta/src/routes/servers/audit_log_query.rs
@@ -106,6 +106,7 @@ mod test {
                 voice: None,
                 slowmode: None,
                 remove: Vec::new(),
+                e2e: None,
             })
             .dispatch()
             .await
@@ -128,6 +129,7 @@ mod test {
                 voice: None,
                 slowmode: None,
                 remove: Vec::new(),
+                e2e: None,
             })
             .dispatch()
             .await

--- a/crates/delta/src/util/test.rs
+++ b/crates/delta/src/util/test.rs
@@ -149,6 +149,7 @@ impl TestHarness {
                 description: None,
                 nsfw: Some(false),
                 voice: None,
+                e2e: None,
             },
             true,
         )

--- a/crates/services/autumn/src/api.rs
+++ b/crates/services/autumn/src/api.rs
@@ -139,6 +139,7 @@ pub struct UploadPayload {
     #[allow(dead_code)]
     #[form_data(limit = "unlimited")] // handled by axum
     file: FieldData<NamedTempFile>,
+    e2e_id: Option<String>,
 }
 
 /// Successful upload response
@@ -179,7 +180,7 @@ async fn upload_file(
     State(db): State<Database>,
     user: User,
     Path(tag): Path<Tag>,
-    TypedMultipart(UploadPayload { mut file }): TypedMultipart<UploadPayload>,
+    TypedMultipart(UploadPayload { mut file, e2e_id }): TypedMultipart<UploadPayload>,
 ) -> Result<Json<UploadResponse>> {
     // Fetch configuration
     let config = config().await;
@@ -241,7 +242,11 @@ async fn upload_file(
     }
 
     // Determine metadata for the file
-    let metadata = generate_metadata(&file.contents, mime_type);
+    let metadata = if e2e_id.is_some() {
+        Metadata::File
+    } else {
+        generate_metadata(&file.contents, mime_type)
+    };
 
     // Block non-images for non-attachment uploads
     if !matches!(tag, Tag::attachments) && !matches!(metadata, Metadata::Image { .. }) {
@@ -260,6 +265,7 @@ async fn upload_file(
                 tag.to_owned(),
                 filename,
                 user.id,
+                e2e_id,
             ))
             .await?;
 
@@ -327,8 +333,14 @@ async fn upload_file(
 
     // Finally, create the file and return its ID
     let tag: &'static str = tag.into();
-    db.insert_attachment(&file_hash.into_file(id.clone(), tag.to_owned(), filename, user.id))
-        .await?;
+    db.insert_attachment(&file_hash.into_file(
+        id.clone(),
+        tag.to_owned(),
+        filename,
+        user.id,
+        e2e_id,
+    ))
+    .await?;
 
     Ok(Json(UploadResponse { id }))
 }


### PR DESCRIPTION
# Note to the Stoat community
This is just a draft and e2ee is a large feature. Don't expect it to be merged soon. Discussion and (if you have a self-host to test with) testing welcome, but expect things to change and plz do not pester staff about timelines.

## Description

- https://github.com/stoatchat/for-web/pull/1579
- https://github.com/stoatchat/javascript-client-sdk/pull/192

Minimal changes to allow e2ee client to recognize e2e encrypted chats and attachment uploads. Could change greatly, and fully willing to rewrite anything wherever team has input.

One change I can think of, push notifications don't even need to contain the message content field. If the chat is marked e2e, the client just shows "\<X\> sent an encrypted message" in notification worker instead of even attempting to decrypt it. This is to prevent leakage of convos via sus Google/Apple/etc push servers.

If instead of a password we use a key exchange like Diffie-Helman plus manual passphrase match check, that would need a new endpoint. Either way though, all approaches worth their salt (haha encryption pun) will require users to confirm out-of-band (aka off platform) for optimal security.

And some quick-and-easy TODOs:
- Need to prevent e2e from being turned off on channel once enabled.
- Bulk delete any existing messages in channel when e2e is enabled. (Client UI already warns this will happen but currently it doesn't lol) They'd only show as invalid once e2e is on anyhow, and encrypting them retroactively would be a bad idea from a 'providing a large amount of known entropy to try and reverse-engineer the key' perspective. That should still be near impossible with AES, but better safe than sorry.
- Storing a known-value secret in channel object for testing the key on would be easier than manually fetching and testing first secure message for validity, that was just a quick-and-dirty temp solution.

## How was this PR tested?
Well, the messages do be working, and attachments too

## Checklist:
- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [ ] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR
This is madness. This is destiny. This is SPARTAAAAAAA
Only thing it's not is AI
