### PR TITLE
fix(tests): PubSub refactor in Delta test harness

### DIFF
--- a/crates/core/database/src/models/bots/model.rs
+++ b/crates/core/database/src/models/bots/model.rs
@@ -173,7 +173,7 @@ mod tests {
 
             let (bot, _) = Bot::create(
                 &db,
-                "Bot Name".to_string(),
+                "Bot-Name".to_string(),
                 &owner,
                 PartialBot {
                     token: Some("my token".to_string()),

--- a/crates/core/database/src/models/server_members/model.rs
+++ b/crates/core/database/src/models/server_members/model.rs
@@ -353,7 +353,7 @@ mod tests {
                 crate::Database::Reference(_) => return,
                 crate::Database::MongoDb(_) => (),
             }
-            let owner = User::create(&db, "Server Owner".to_string(), None, None)
+            let owner = User::create(&db, "ServerOwner".to_string(), None, None)
                 .await
                 .unwrap();
 

--- a/crates/core/result/src/lib.rs
+++ b/crates/core/result/src/lib.rs
@@ -36,12 +36,12 @@ pub struct Error {
     pub error_type: ErrorType,
 
     /// Where this error occurred
-    pub location: String,
+    pub location: Option<String>,
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?} occurred in {}", self.error_type, self.location)
+        write!(f, "{:?} occurred in {:?}", self.error_type, self.location)
     }
 }
 
@@ -65,7 +65,7 @@ impl serde::Serialize for Error {
                 | ErrorType::UnverifiedAccount
                 | ErrorType::LockedOut
                 | ErrorType::DisallowedMFAMethod => None,
-            _ => Some(self.location.as_str()),
+            _ => Some(self.location.as_deref().unwrap()),
         };
 
         Body {
@@ -254,7 +254,7 @@ macro_rules! create_error {
     ( $error: ident $( $tt:tt )? ) => {
         $crate::Error {
             error_type: $crate::ErrorType::$error $( $tt )?,
-            location: format!("{}:{}:{}", file!(), line!(), column!()),
+            location: format!("{}:{}:{}", file!(), line!(), column!()).into(),
         }
     };
 }
@@ -303,7 +303,7 @@ impl<T, E: std::fmt::Debug + std::error::Error> ToRevoltError<T> for Result<T, E
 
             Error {
                 error_type: ErrorType::InternalError,
-                location: format!("{}:{}:{}", loc.file(), loc.line(), loc.column()),
+                location: format!("{}:{}:{}", loc.file(), loc.line(), loc.column()).into(),
             }
         })
     }
@@ -316,7 +316,7 @@ impl<T> ToRevoltError<T> for Option<T> {
 
         self.ok_or_else(|| Error {
             error_type: ErrorType::InternalError,
-            location: format!("{}:{}:{}", loc.file(), loc.line(), loc.column()),
+            location: format!("{}:{}:{}", loc.file(), loc.line(), loc.column()).into(),
         })
     }
 }

--- a/crates/delta/src/routes/account/create_account.rs
+++ b/crates/delta/src/routes/account/create_account.rs
@@ -79,10 +79,12 @@ mod tests {
     use revolt_database::{events::client::EventV1, AccountInvite};
     use revolt_result::{Error, ErrorType};
     use rocket::http::{ContentType, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn success() {
         let mut harness = TestHarness::new().await;
+        let mut pubsub = PubSubTestHelper::new("global").await;
 
         let res = harness
             .client
@@ -101,8 +103,8 @@ mod tests {
         assert_eq!(res.status(), Status::NoContent);
         drop(res);
 
-        harness
-            .wait_for_event("global", |e| matches!(e, EventV1::CreateAccount { .. }))
+        pubsub
+            .wait_for_event(|e| matches!(e, EventV1::CreateAccount { .. }))
             .await;
     }
 

--- a/crates/delta/src/routes/account/create_account.rs
+++ b/crates/delta/src/routes/account/create_account.rs
@@ -104,8 +104,10 @@ mod tests {
         drop(res);
 
         pubsub
-            .wait_for_event(|e| matches!(e, EventV1::CreateAccount { .. }))
-            .await;
+            .wait_for_event(|event| match event {
+                EventV1::CreateAccount { account } => account.email == "success@validemail.com",
+                _ => false,
+            }).await;
     }
 
     #[rocket::async_test]

--- a/crates/delta/src/routes/account/create_account.rs
+++ b/crates/delta/src/routes/account/create_account.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[rocket::async_test]
     async fn success() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let mut pubsub = PubSubTestHelper::new("global").await;
 
         let res = harness

--- a/crates/delta/src/routes/account/disable_account.rs
+++ b/crates/delta/src/routes/account/disable_account.rs
@@ -24,11 +24,13 @@ mod tests {
     use revolt_database::{MFATicket, events::client::EventV1};
     use revolt_result::ErrorType;
     use rocket::http::{Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn success() {
         let mut harness = TestHarness::new().await;
         let (account, session, _) = harness.new_user().await;
+        let mut pubsub = PubSubTestHelper::new(&format!("{}!", &account.id)).await;
 
         let ticket = MFATicket::new(account.id.to_string(), true);
         ticket.save(&harness.db).await.unwrap();
@@ -58,7 +60,7 @@ mod tests {
             ErrorType::UnknownUser
         ));
 
-        harness.wait_for_event(&format!("{}!", &account.id), |e| if let EventV1::DeleteAllSessions { user_id, .. } = e {
+        pubsub.wait_for_event(|e| if let EventV1::DeleteAllSessions { user_id, .. } = e {
             user_id == &account.id
         } else {
             false

--- a/crates/delta/src/routes/account/disable_account.rs
+++ b/crates/delta/src/routes/account/disable_account.rs
@@ -28,7 +28,7 @@ mod tests {
 
     #[rocket::async_test]
     async fn success() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (account, session, _) = harness.new_user().await;
         let mut pubsub = PubSubTestHelper::new(&format!("{}!", &account.id)).await;
 

--- a/crates/delta/src/routes/bots/delete.rs
+++ b/crates/delta/src/routes/bots/delete.rs
@@ -35,6 +35,7 @@ mod test {
     use crate::{rocket, util::test::TestHarness};
     use revolt_database::{events::client::EventV1, Bot};
     use rocket::http::{Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn delete_bot() {
@@ -44,6 +45,7 @@ mod test {
         let (bot, _) = Bot::create(&harness.db, TestHarness::rand_string(), &user, None)
             .await
             .expect("`Bot`");
+        let mut pubsub = PubSubTestHelper::new(&bot.id).await;
 
         let response = harness
             .client
@@ -56,8 +58,8 @@ mod test {
         assert!(harness.db.fetch_bot(&bot.id).await.is_err());
         drop(response);
 
-        let event = harness
-            .wait_for_event(&bot.id, |event| match event {
+        let event = pubsub
+            .wait_for_event(|event| match event {
                 EventV1::UserUpdate { id, .. } => id == &bot.id,
                 _ => false,
             })

--- a/crates/delta/src/routes/bots/delete.rs
+++ b/crates/delta/src/routes/bots/delete.rs
@@ -39,7 +39,7 @@ mod test {
 
     #[rocket::async_test]
     async fn delete_bot() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
 
         let (bot, _) = Bot::create(&harness.db, TestHarness::rand_string(), &user, None)

--- a/crates/delta/src/routes/bots/invite.rs
+++ b/crates/delta/src/routes/bots/invite.rs
@@ -69,6 +69,7 @@ mod test {
     use revolt_database::{events::client::EventV1, Bot, Channel, Server};
     use revolt_models::v0::{self, DataCreateServer};
     use rocket::http::{ContentType, Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn invite_bot_to_group() {
@@ -89,6 +90,7 @@ mod test {
         )
         .await
         .unwrap();
+        let mut pubsub = PubSubTestHelper::new(group.id()).await;
 
         let response = harness
             .client
@@ -107,8 +109,8 @@ mod test {
         assert_eq!(response.status(), Status::NoContent);
         drop(response);
 
-        let event = harness
-            .wait_for_event(group.id(), |event| match event {
+        let event = pubsub
+            .wait_for_event(|event| match event {
                 EventV1::ChannelGroupJoin { id, .. } => id == group.id(),
                 _ => false,
             })
@@ -142,6 +144,7 @@ mod test {
         )
         .await
         .unwrap();
+        let mut pubsub = PubSubTestHelper::new(&server.id).await;
 
         let response = harness
             .client
@@ -160,8 +163,8 @@ mod test {
         assert_eq!(response.status(), Status::NoContent);
         drop(response);
 
-        let event = harness
-            .wait_for_event(&server.id, |event| match event {
+        let event = pubsub
+            .wait_for_event(|event| match event {
                 EventV1::ServerMemberJoin { id, .. } => id == &server.id,
                 _ => false,
             })

--- a/crates/delta/src/routes/bots/invite.rs
+++ b/crates/delta/src/routes/bots/invite.rs
@@ -73,7 +73,7 @@ mod test {
 
     #[rocket::async_test]
     async fn invite_bot_to_group() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
 
         let (bot, _) = Bot::create(&harness.db, TestHarness::rand_string(), &user, None)
@@ -126,7 +126,7 @@ mod test {
 
     #[rocket::async_test]
     async fn invite_bot_to_server() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
 
         let (bot, _) = Bot::create(&harness.db, TestHarness::rand_string(), &user, None)

--- a/crates/delta/src/routes/channels/channel_ack.rs
+++ b/crates/delta/src/routes/channels/channel_ack.rs
@@ -41,11 +41,13 @@ mod test {
     use revolt_database::{events::client::EventV1, Channel};
     use revolt_models::v0::DataCreateGroup;
     use rocket::http::{Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn success_ack_channel() {
         let mut harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
+        let mut pubsub = PubSubTestHelper::new(&format!("{}!", user.id)).await;
 
         let group = Channel::create_group(
             &harness.db,
@@ -68,8 +70,8 @@ mod test {
         assert_eq!(response.status(), Status::NoContent);
         drop(response);
 
-        let event = harness
-            .wait_for_event(&format!("{}!", user.id), |event| match event {
+        let event = pubsub
+            .wait_for_event(|event| match event {
                 EventV1::ChannelAck { id, .. } => id == group.id(),
                 _ => false,
             })

--- a/crates/delta/src/routes/channels/channel_ack.rs
+++ b/crates/delta/src/routes/channels/channel_ack.rs
@@ -45,7 +45,7 @@ mod test {
 
     #[rocket::async_test]
     async fn success_ack_channel() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
         let mut pubsub = PubSubTestHelper::new(&format!("{}!", user.id)).await;
 

--- a/crates/delta/src/routes/channels/channel_delete.rs
+++ b/crates/delta/src/routes/channels/channel_delete.rs
@@ -86,10 +86,12 @@ pub async fn delete(
 
 #[cfg(test)]
 mod test {
+    use redis_kiss::redis::PubSub;
     use crate::{rocket, util::test::TestHarness};
     use revolt_database::{events::client::EventV1, Channel};
     use revolt_models::v0::DataCreateGroup;
     use rocket::http::{Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn success_delete_group() {
@@ -106,6 +108,8 @@ mod test {
         .await
         .expect("`Channel`");
 
+        let mut pubsub = PubSubTestHelper::new(group.id()).await;
+
         let response = harness
             .client
             .delete(format!("/channels/{}", group.id()))
@@ -116,8 +120,8 @@ mod test {
         assert_eq!(response.status(), Status::NoContent);
         drop(response);
 
-        harness
-            .wait_for_event(group.id(), |event| match event {
+        pubsub
+            .wait_for_event( |event| match event {
                 EventV1::ChannelDelete { id, .. } => id == group.id(),
                 _ => false,
             })
@@ -133,6 +137,7 @@ mod test {
         let mut harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
         let (_, channels) = harness.new_server(&user).await;
+        let mut pubsub = PubSubTestHelper::new(channels[0].id()).await;
         let response = TestHarness::with_session(
             session,
             harness
@@ -142,8 +147,8 @@ mod test {
         .await;
         assert_eq!(response.status(), Status::NoContent);
         drop(response);
-        harness
-            .wait_for_event(channels[0].id(), |event| match event {
+        pubsub
+            .wait_for_event(|event| match event {
                 EventV1::ChannelDelete { id, .. } => id == channels[0].id(),
                 _ => false,
             })

--- a/crates/delta/src/routes/channels/channel_delete.rs
+++ b/crates/delta/src/routes/channels/channel_delete.rs
@@ -86,7 +86,6 @@ pub async fn delete(
 
 #[cfg(test)]
 mod test {
-    use redis_kiss::redis::PubSub;
     use crate::{rocket, util::test::TestHarness};
     use revolt_database::{events::client::EventV1, Channel};
     use revolt_models::v0::DataCreateGroup;

--- a/crates/delta/src/routes/channels/channel_delete.rs
+++ b/crates/delta/src/routes/channels/channel_delete.rs
@@ -94,7 +94,7 @@ mod test {
 
     #[rocket::async_test]
     async fn success_delete_group() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
 
         let group = Channel::create_group(
@@ -133,7 +133,7 @@ mod test {
 
     #[rocket::async_test]
     async fn success_delete_channel() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
         let (_, channels) = harness.new_server(&user).await;
         let mut pubsub = PubSubTestHelper::new(channels[0].id()).await;

--- a/crates/delta/src/routes/channels/group_add_member.rs
+++ b/crates/delta/src/routes/channels/group_add_member.rs
@@ -53,12 +53,15 @@ mod test {
     use revolt_database::{events::client::EventV1, Channel, RelationshipStatus};
     use revolt_models::v0;
     use rocket::http::{Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn success_add_member() {
         let mut harness = TestHarness::new().await;
         let (_, session, mut user) = harness.new_user().await;
         let (_, _, mut other_user) = harness.new_user().await;
+        let mut other_user_pubsub = PubSubTestHelper::new(
+            &format!("{}!", other_user.id)).await;
 
         #[allow(clippy::disallowed_methods)]
         user.apply_relationship(
@@ -80,6 +83,7 @@ mod test {
         )
         .await
         .unwrap();
+        let mut group_pubsub = PubSubTestHelper::new(group.id()).await;
 
         let response = harness
             .client
@@ -95,15 +99,15 @@ mod test {
         assert_eq!(response.status(), Status::NoContent);
         drop(response);
 
-        harness
-            .wait_for_event(&format!("{}!", other_user.id), |event| match event {
+        other_user_pubsub
+            .wait_for_event(|event| match event {
                 EventV1::ChannelCreate(channel) => channel.id() == group.id(),
                 _ => false,
             })
             .await;
 
-        let event = harness
-            .wait_for_event(group.id(), |event| match event {
+        let event = group_pubsub
+            .wait_for_event(|event| match event {
                 EventV1::ChannelGroupJoin { id, .. } => id == group.id(),
                 _ => false,
             })
@@ -114,7 +118,7 @@ mod test {
             _ => unreachable!(),
         };
 
-        let message = harness.wait_for_message(group.id()).await;
+        let message = group_pubsub.wait_for_message().await;
 
         assert_eq!(
             message.system,

--- a/crates/delta/src/routes/channels/group_add_member.rs
+++ b/crates/delta/src/routes/channels/group_add_member.rs
@@ -60,8 +60,7 @@ mod test {
         let mut harness = TestHarness::new().await;
         let (_, session, mut user) = harness.new_user().await;
         let (_, _, mut other_user) = harness.new_user().await;
-        let mut other_user_pubsub = PubSubTestHelper::new(
-            &format!("{}!", other_user.id)).await;
+        let mut other_user_pubsub = PubSubTestHelper::new(&format!("{}!", other_user.id)).await;
 
         #[allow(clippy::disallowed_methods)]
         user.apply_relationship(

--- a/crates/delta/src/routes/channels/group_add_member.rs
+++ b/crates/delta/src/routes/channels/group_add_member.rs
@@ -57,7 +57,7 @@ mod test {
 
     #[rocket::async_test]
     async fn success_add_member() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, mut user) = harness.new_user().await;
         let (_, _, mut other_user) = harness.new_user().await;
         let mut other_user_pubsub = PubSubTestHelper::new(&format!("{}!", other_user.id)).await;

--- a/crates/delta/src/routes/channels/group_create.rs
+++ b/crates/delta/src/routes/channels/group_create.rs
@@ -45,11 +45,13 @@ mod test {
     use revolt_database::events::client::EventV1;
     use revolt_models::v0;
     use rocket::http::{ContentType, Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn create_group() {
         let mut harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
+        let mut pubsub = PubSubTestHelper::new(&format!("{}!", user.id)).await;
 
         let response = harness
             .client
@@ -79,8 +81,8 @@ mod test {
                 assert_eq!(recipients.len(), 1);
                 assert!(harness.db.fetch_channel(&id).await.is_ok());
 
-                let event = harness
-                    .wait_for_event(&format!("{}!", user.id), |event| match event {
+                let event = pubsub
+                    .wait_for_event(|event| match event {
                         EventV1::ChannelCreate(channel) => channel.id() == id,
                         _ => false,
                     })

--- a/crates/delta/src/routes/channels/group_create.rs
+++ b/crates/delta/src/routes/channels/group_create.rs
@@ -49,7 +49,7 @@ mod test {
 
     #[rocket::async_test]
     async fn create_group() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
         let mut pubsub = PubSubTestHelper::new(&format!("{}!", user.id)).await;
 

--- a/crates/delta/src/routes/channels/group_remove_member.rs
+++ b/crates/delta/src/routes/channels/group_remove_member.rs
@@ -69,12 +69,15 @@ mod test {
     use revolt_database::{events::client::EventV1, Channel, RelationshipStatus};
     use revolt_models::v0;
     use rocket::http::{Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn success_remove_member() {
         let mut harness = TestHarness::new().await;
         let (_, session, mut user) = harness.new_user().await;
         let (_, _, mut other_user) = harness.new_user().await;
+        let mut other_user_pubsub = PubSubTestHelper::new(
+            &format!("{}!", other_user.id)).await;
 
         #[allow(clippy::disallowed_methods)]
         user.apply_relationship(
@@ -96,6 +99,7 @@ mod test {
         )
         .await
         .unwrap();
+        let mut group_pubsub = PubSubTestHelper::new(group.id()).await;
 
         let response = harness
             .client
@@ -111,15 +115,15 @@ mod test {
         assert_eq!(response.status(), Status::NoContent);
         drop(response);
 
-        harness
-            .wait_for_event(&format!("{}!", other_user.id), |event| match event {
+        other_user_pubsub
+            .wait_for_event(|event| match event {
                 EventV1::ChannelCreate(channel) => channel.id() == group.id(),
                 _ => false,
             })
             .await;
 
-        let event = harness
-            .wait_for_event(group.id(), |event| match event {
+        let event = group_pubsub
+            .wait_for_event(|event| match event {
                 EventV1::ChannelGroupJoin { id, .. } => id == group.id(),
                 _ => false,
             })
@@ -130,7 +134,7 @@ mod test {
             _ => unreachable!(),
         };
 
-        let message = harness.wait_for_message(group.id()).await;
+        let message = group_pubsub.wait_for_message().await;
 
         assert_eq!(
             message.system,

--- a/crates/delta/src/routes/channels/group_remove_member.rs
+++ b/crates/delta/src/routes/channels/group_remove_member.rs
@@ -76,8 +76,7 @@ mod test {
         let mut harness = TestHarness::new().await;
         let (_, session, mut user) = harness.new_user().await;
         let (_, _, mut other_user) = harness.new_user().await;
-        let mut other_user_pubsub = PubSubTestHelper::new(
-            &format!("{}!", other_user.id)).await;
+        let mut other_user_pubsub = PubSubTestHelper::new(&format!("{}!", other_user.id)).await;
 
         #[allow(clippy::disallowed_methods)]
         user.apply_relationship(

--- a/crates/delta/src/routes/channels/group_remove_member.rs
+++ b/crates/delta/src/routes/channels/group_remove_member.rs
@@ -73,7 +73,7 @@ mod test {
 
     #[rocket::async_test]
     async fn success_remove_member() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, mut user) = harness.new_user().await;
         let (_, _, mut other_user) = harness.new_user().await;
         let mut other_user_pubsub = PubSubTestHelper::new(&format!("{}!", other_user.id)).await;

--- a/crates/delta/src/routes/channels/message_pin.rs
+++ b/crates/delta/src/routes/channels/message_pin.rs
@@ -97,6 +97,7 @@ mod test {
     };
     use revolt_models::v0::{self, SystemMessage};
     use rocket::http::{Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn pin_message() {
@@ -119,6 +120,7 @@ mod test {
             .await
             .expect("Failed to create member");
         let channel = &channels[0];
+        let mut pubsub = PubSubTestHelper::new(channel.id()).await;
 
         let message = Message::create_from_api(
             &harness.db,
@@ -159,8 +161,8 @@ mod test {
         assert_eq!(response.status(), Status::NoContent);
         drop(response);
 
-        harness
-            .wait_for_event(channel.id(), |event| match event {
+        pubsub
+            .wait_for_event(|event| match event {
                 EventV1::Message(message) => match &message.system {
                     Some(SystemMessage::MessagePinned { by, .. }) => {
                         assert_eq!(by, &user.id);
@@ -173,8 +175,8 @@ mod test {
             })
             .await;
 
-        harness
-            .wait_for_event(channel.id(), |event| match event {
+        pubsub
+            .wait_for_event(|event| match event {
                 EventV1::MessageUpdate {
                     id,
                     channel: channel_id,

--- a/crates/delta/src/routes/channels/message_pin.rs
+++ b/crates/delta/src/routes/channels/message_pin.rs
@@ -101,7 +101,7 @@ mod test {
 
     #[rocket::async_test]
     async fn pin_message() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
 
         let (server, channels) = Server::create(

--- a/crates/delta/src/routes/channels/message_unpin.rs
+++ b/crates/delta/src/routes/channels/message_unpin.rs
@@ -91,6 +91,7 @@ mod test {
     };
     use revolt_models::v0::{self, FieldsMessage, SystemMessage};
     use rocket::http::{Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn unpin_message() {
@@ -110,6 +111,7 @@ mod test {
         .expect("Failed to create test server");
 
         let channel = &channels[0];
+        let mut pubsub = PubSubTestHelper::new(channel.id()).await;
 
         Member::create(&harness.db, &server, &user, Some(channels.clone()))
             .await
@@ -171,8 +173,8 @@ mod test {
         assert_eq!(response.status(), Status::NoContent);
         drop(response);
 
-        harness
-            .wait_for_event(channel.id(), |event| match event {
+        pubsub
+            .wait_for_event(|event| match event {
                 EventV1::Message(message) => match &message.system {
                     Some(SystemMessage::MessageUnpinned { by, .. }) => {
                         assert_eq!(by, &user.id);
@@ -185,8 +187,8 @@ mod test {
             })
             .await;
 
-        harness
-            .wait_for_event(channel.id(), |event| match event {
+        pubsub
+            .wait_for_event(|event| match event {
                 EventV1::MessageUpdate { id, clear, .. } => {
                     assert_eq!(&message.id, id);
                     assert_eq!(clear, &[FieldsMessage::Pinned]);

--- a/crates/delta/src/routes/channels/message_unpin.rs
+++ b/crates/delta/src/routes/channels/message_unpin.rs
@@ -95,7 +95,7 @@ mod test {
 
     #[rocket::async_test]
     async fn unpin_message() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, user) = harness.new_user().await;
 
         let (server, channels) = Server::create(

--- a/crates/delta/src/routes/session/login.rs
+++ b/crates/delta/src/routes/session/login.rs
@@ -170,10 +170,12 @@ mod tests {
     use rocket::http::{ContentType, Status};
     use revolt_models::v0;
     use revolt_result::{Error, ErrorType};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn success() {
         let mut harness = TestHarness::new().await;
+        let mut pubsub = PubSubTestHelper::new("global").await;
 
         Account::new(
             &harness.db,
@@ -184,7 +186,7 @@ mod tests {
         .await
         .unwrap();
 
-        harness.wait_for_event("global", |_| true).await;
+        pubsub.wait_for_event(|_| true).await;
 
         let res = harness.client
             .post("/auth/session/login")
@@ -202,7 +204,7 @@ mod tests {
         assert_eq!(res.status(), Status::Ok);
         assert!(res.into_json::<v0::Session>().await.is_some());
 
-        let event = harness.wait_for_event("global", |_| true).await;
+        let event = pubsub.wait_for_event(|_| true).await;
         if !matches!(event, EventV1::CreateSession { .. }) {
             panic!("Received incorrect event type. {:?}", event);
         }

--- a/crates/delta/src/routes/session/login.rs
+++ b/crates/delta/src/routes/session/login.rs
@@ -172,9 +172,8 @@ mod tests {
     #[rocket::async_test]
     async fn success() {
         let harness = TestHarness::new().await;
-        let mut pubsub = PubSubTestHelper::new("global").await;
 
-        Account::new(
+        let account = Account::new(
             &harness.db,
             "example@validemail.com".into(),
             "password_insecure".into(),
@@ -183,7 +182,7 @@ mod tests {
         .await
         .unwrap();
 
-        pubsub.wait_for_event(|_| true).await;
+        let mut pubsub = PubSubTestHelper::new("global").await;
 
         let res = harness
             .client
@@ -202,7 +201,10 @@ mod tests {
         assert_eq!(res.status(), Status::Ok);
         assert!(res.into_json::<v0::Session>().await.is_some());
 
-        let event = pubsub.wait_for_event(|_| true).await;
+        let event = pubsub.wait_for_event(|event| match event {
+            EventV1::CreateSession { session } => session.user_id == account.id,
+            _ => false,
+        }).await;
         if !matches!(event, EventV1::CreateSession { .. }) {
             panic!("Received incorrect event type. {:?}", event);
         }

--- a/crates/delta/src/routes/session/login.rs
+++ b/crates/delta/src/routes/session/login.rs
@@ -171,7 +171,7 @@ mod tests {
 
     #[rocket::async_test]
     async fn success() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let mut pubsub = PubSubTestHelper::new("global").await;
 
         Account::new(

--- a/crates/delta/src/routes/session/logout.rs
+++ b/crates/delta/src/routes/session/logout.rs
@@ -20,11 +20,13 @@ mod tests {
     use revolt_database::events::client::EventV1;
     use revolt_result::ErrorType;
     use rocket::http::{Header, Status};
+    use crate::util::test::PubSubTestHelper;
 
     #[rocket::async_test]
     async fn success() {
         let mut harness = TestHarness::new().await;
         let (_, session, _) = harness.new_user().await;
+        let mut pubsub = PubSubTestHelper::new(&format!("{}!", &session.user_id)).await;
 
         let res = harness.client
             .post("/auth/session/logout")
@@ -42,7 +44,7 @@ mod tests {
             ErrorType::UnknownUser
         ));
 
-        let event = harness.wait_for_event(&format!("{}!", &session.user_id), |evt| matches!(evt, EventV1::DeleteSession { .. })).await;
+        let event = pubsub.wait_for_event(|evt| matches!(evt, EventV1::DeleteSession { .. })).await;
         if let EventV1::DeleteSession {
             user_id,
             session_id,

--- a/crates/delta/src/routes/session/logout.rs
+++ b/crates/delta/src/routes/session/logout.rs
@@ -24,7 +24,7 @@ mod tests {
 
     #[rocket::async_test]
     async fn success() {
-        let mut harness = TestHarness::new().await;
+        let harness = TestHarness::new().await;
         let (_, session, _) = harness.new_user().await;
         let mut pubsub = PubSubTestHelper::new(&format!("{}!", &session.user_id)).await;
 

--- a/crates/delta/src/util/test.rs
+++ b/crates/delta/src/util/test.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use rand::Rng;
 use redis_kiss::redis::aio::PubSub;
 use revolt_database::util::email::normalise_email;
@@ -227,6 +227,7 @@ impl TestHarness {
 
 pub struct PubSubTestHelper {
     sub: PubSub,
+    event_buffer: Vec<(String, EventV1)>,
 }
 
 impl PubSubTestHelper {
@@ -239,6 +240,7 @@ impl PubSubTestHelper {
 
         PubSubTestHelper {
             sub,
+            event_buffer: vec![],
         }
     }
 
@@ -246,12 +248,34 @@ impl PubSubTestHelper {
     where
         F: Fn(&EventV1) -> bool,
     {
+        for (_, event) in &self.event_buffer {
+            if predicate(event) {
+                // does not remove from buffer
+                return event.clone();
+            }
+        }
+
         let mut stream = self.sub.on_message();
         while let Some(item) = stream.next().await {
             let msg_topic = item.get_channel_name();
             let payload: EventV1 = redis_kiss::decode_payload(&item).unwrap();
 
-            return payload;
+            if predicate(&payload) {
+                let matched = payload;
+
+                // Saw this used while chasing ghosts in the Redis stream, s/o Alice Ryhl
+                // Seems to be necessary when events on the same channel arrive too quickly
+                while let Some(Some(item)) = stream.next().now_or_never() {
+                    let msg_topic = item.get_channel_name().to_string();
+                    let payload: EventV1 = redis_kiss::decode_payload(&item).unwrap();
+
+                    self.event_buffer.push((msg_topic, payload));
+                }
+
+                return matched;
+            }
+
+            self.event_buffer.push((msg_topic.to_string(), payload));
         }
 
         // WARNING: if predicate is never satisfied, this will never return
@@ -261,6 +285,8 @@ impl PubSubTestHelper {
     }
 
     pub async fn wait_for_message(&mut self) -> v0::Message {
+        dbg!(&self.event_buffer);
+
         match self
             .wait_for_event(|event| match event {
                 EventV1::Message(v0::Message { channel, .. }) => !channel.trim().is_empty(),

--- a/crates/delta/src/util/test.rs
+++ b/crates/delta/src/util/test.rs
@@ -21,8 +21,6 @@ pub struct TestHarness {
     pub client: Client,
     pub db: Database,
     pub amqp: AMQP,
-    sub: PubSub,
-    event_buffer: Vec<(String, EventV1)>,
 }
 
 impl TestHarness {
@@ -30,12 +28,6 @@ impl TestHarness {
         let client = Client::tracked(crate::web().await)
             .await
             .expect("valid rocket instance");
-
-        let mut sub = redis_kiss::open_pubsub_connection()
-            .await
-            .expect("`PubSub`");
-
-        sub.psubscribe("*").await.unwrap();
 
         let db = client
             .rocket()
@@ -49,8 +41,6 @@ impl TestHarness {
             client,
             db,
             amqp,
-            sub,
-            event_buffer: vec![],
         }
     }
 
@@ -200,35 +190,6 @@ impl TestHarness {
             .await
     }
 
-    pub async fn wait_for_event<F>(&mut self, topic: &str, predicate: F) -> EventV1
-    where
-        F: Fn(&EventV1) -> bool,
-    {
-        for (msg_topic, event) in &self.event_buffer {
-            if topic == msg_topic && predicate(event) {
-                // does not remove from buffer
-                return event.clone();
-            }
-        }
-
-        let mut stream = self.sub.on_message();
-        while let Some(item) = stream.next().await {
-            let msg_topic = item.get_channel_name();
-            let payload: EventV1 = redis_kiss::decode_payload(&item).unwrap();
-
-            if topic == msg_topic && predicate(&payload) {
-                return payload;
-            }
-
-            self.event_buffer.push((msg_topic.to_string(), payload));
-        }
-
-        // WARNING: if predicate is never satisfied, this will never return
-        //          should add a timeout for events so tests can fail gracefully
-
-        unreachable!()
-    }
-
     pub async fn assert_email(&self, mailbox: &str) -> (Mail, String) {
         // Wait a moment for maildev to catch the email
 
@@ -262,13 +223,47 @@ impl TestHarness {
 
         panic!("Email not found.")
     }
+}
 
-    pub async fn wait_for_message(&mut self, channel_id: &str) -> v0::Message {
-        dbg!(&self.event_buffer);
+pub struct PubSubTestHelper {
+    sub: PubSub,
+}
 
+impl PubSubTestHelper {
+    pub async fn new (topic: &str) -> Self {
+        let mut sub = redis_kiss::open_pubsub_connection()
+            .await
+            .expect("`PubSub`");
+
+        sub.subscribe(topic).await.unwrap();
+
+        PubSubTestHelper {
+            sub,
+        }
+    }
+
+    pub async fn wait_for_event<F>(&mut self, predicate: F) -> EventV1
+    where
+        F: Fn(&EventV1) -> bool,
+    {
+        let mut stream = self.sub.on_message();
+        while let Some(item) = stream.next().await {
+            let msg_topic = item.get_channel_name();
+            let payload: EventV1 = redis_kiss::decode_payload(&item).unwrap();
+
+            return payload;
+        }
+
+        // WARNING: if predicate is never satisfied, this will never return
+        //          should add a timeout for events so tests can fail gracefully
+
+        unreachable!()
+    }
+
+    pub async fn wait_for_message(&mut self) -> v0::Message {
         match self
-            .wait_for_event(channel_id, |event| match event {
-                EventV1::Message(v0::Message { channel, .. }) => channel == channel_id,
+            .wait_for_event(|event| match event {
+                EventV1::Message(v0::Message { channel, .. }) => !channel.trim().is_empty(),
                 _ => false,
             })
             .await


### PR DESCRIPTION
<!-- Describe your changes -->

There've been some issues with flaky tests in Delta. It seems to occur when there are too many publishers and subscribers to PubSub, since each TestHarness object was making its own wildcard substitution to all events.

This PR split out the PubSub logic to a different object to avoid changing the signature of TestHarness::new(). From there, I've given the tests that actually check for events a subscription to specifically the channel of interest to that test. Some additional changes were needed since it seems like it was still failing if two events arrived on the same channel too close together; some of the test harness code borrowed liberally from an Alice Ryhl comment on StackOverflow in 2021.

UPDATE: After the bump to Rust 2024 this PR also includes some additional fixes to the test suite to account for the changes made to username validation and the location property on errors being made optional.

## How was this PR tested?

<!-- What did you do to test your changes? -->

- Ran `mise test`
- Ran `mise test` again but with a high degree of test parallelism (which would previously choke: see #932 )

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code (I mean, mostly)

## Please declare, if any, LLM usage involved in creating this PR

None.
