### PR TITLE
fix: support mp4 audio mime

### DIFF
--- a/crates/services/autumn/src/mime_type.rs
+++ b/crates/services/autumn/src/mime_type.rs
@@ -26,5 +26,30 @@ pub fn determine_mime_type(f: &mut NamedTempFile, buf: &[u8], file_name: &str) -
         }
     }
 
+    // Specify the MP4 mime type further by looking at the media streams, as some MP4 files are audio, not video.
+    if mime_type == "video/mp4" {
+        let Ok(probe) = ffprobe::ffprobe(f.path()) else {
+            return mime_type;
+        };
+
+        let (mut has_audio, mut has_video) = (false, false);
+
+        for codec_type in probe
+            .streams
+            .iter()
+            .filter_map(|stream| stream.codec_type.as_deref())
+        {
+            match codec_type {
+                "audio" => has_audio = true,
+                "video" => has_video = true,
+                _ => {}
+            }
+        }
+
+        if has_audio && !has_video {
+            return "audio/mp4";
+        }
+    }
+
     mime_type
 }


### PR DESCRIPTION
<!-- Describe your changes -->

Fixes an issue in which mp4 audio (.m4a) files from certain sources, such as the Android API, would not be recognised as audio by the `infer` crate due to the use of generic mp4 headers, causing the file to be classed as neither video nor audio, but a generic file.

The fix calls into ffprobe and checks for the presence of audio and video streams to assign the proper mime-type.

## How was this PR tested?

<!-- What did you do to test your changes? -->

- [x] I ran the backend locally and uploaded .mp4 files with video only, .m4a files with audio only, and .mp4 files with both combined. I confirmed that .m4a is now properly recognised as an audio file w/ an inline player rather than a generic file.

## Checklist:

- [x] I have carefully read [the contributing guidelines](https://developers.stoat.chat/developing/contrib/)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR
- [x] I have confirmed that any new dependencies are strictly necessary
- [x] I have written tests for new code (if applicable)
- [x] I have followed naming conventions/patterns in the surrounding code

## Please declare, if any, LLM usage involved in creating this PR

Tradcoded 🤠️

- `main` <!-- branch-stack -->
  - \#987 :point\_left:
